### PR TITLE
duplicate json fix

### DIFF
--- a/training/src/main/java/com/revature/caliber/training/data/implementations/WeekDAOImplementation.java
+++ b/training/src/main/java/com/revature/caliber/training/data/implementations/WeekDAOImplementation.java
@@ -40,7 +40,7 @@ public class WeekDAOImplementation implements WeekDAO {
 		Session session = sessionFactory.getCurrentSession();
 		Criteria criteria = session.createCriteria(Week.class);
 		criteria.add(Restrictions.eq("batch.batchId", batchId));
-		return criteria.list();
+		return criteria.setResultTransformer(Criteria.DISTINCT_ROOT_ENTITY).list();
 	}
 
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED, rollbackFor = Exception.class)
@@ -54,7 +54,7 @@ public class WeekDAOImplementation implements WeekDAO {
 		Session session = sessionFactory.getCurrentSession();
 		Criteria criteria = session.createCriteria(Week.class);
 		criteria.add(Restrictions.eq("weekNumber", weekNumber));
-		return criteria.list();
+		return criteria.setResultTransformer(Criteria.DISTINCT_ROOT_ENTITY).list();
 	}
 
 }

--- a/training/src/main/java/com/revature/caliber/training/web/controllers/WeekController.java
+++ b/training/src/main/java/com/revature/caliber/training/web/controllers/WeekController.java
@@ -112,11 +112,10 @@ public class WeekController {
 	 * @param week
 	 * @return
 	 */
-    @RequestMapping(value = "/week/new/{batchId}",
+    @RequestMapping(value = "/week/new",
             method = RequestMethod.POST,
-            consumes = MediaType.APPLICATION_JSON_VALUE,
-            produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<Serializable> createWeek(@PathVariable("batchId") int batchId, @RequestBody @Valid Week week) {
+            consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Serializable> createWeek( @RequestBody @Valid Week week ) {
         ResponseEntity<Serializable> returnEntity;
         try {
             businessDelegate.createWeek(week);
@@ -127,5 +126,4 @@ public class WeekController {
         }
         return returnEntity;
     }
-	
 }

--- a/training/src/test/java/com/revature/caliber/data/implementations/WeekDAOImplementationTest.java
+++ b/training/src/test/java/com/revature/caliber/data/implementations/WeekDAOImplementationTest.java
@@ -59,7 +59,7 @@ public class WeekDAOImplementationTest {
 		logger.debug(" fetching all week records where batch id = 1 \n");
 		listOfWeeks = dao.getWeekByBatchId(1);
 
-		assertNotNull(listOfWeeks);;
+		assertEquals(1, listOfWeeks.get(0).getBatch().getBatchId());
 		logger.debug(" successfully fetched all week records  \n");
 
 	}


### PR DESCRIPTION
Initially fixed duplicate json by changing eager to lazy, but it caused lazy instantiation error. So I added .setResultTransformer(Criteria.DISTINCT_ROOT_ENTITY) to criteria list which also fixed the problem. I could have also changed list to set but it would not fit the convention.