### PR TITLE
Issue/609

### DIFF
--- a/caliber/src/main/java/com/revature/caliber/controllers/AssessmentController.java
+++ b/caliber/src/main/java/com/revature/caliber/controllers/AssessmentController.java
@@ -106,7 +106,7 @@ public class AssessmentController {
 	 */
 	@RequestMapping(value = "/trainer/assessment/{batchId}/{week}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
-	@PreAuthorize("hasAnyRole('VP', 'TRAINER')")
+	@PreAuthorize("hasAnyRole('VP', 'TRAINER', 'STAGING')")
 	public ResponseEntity<List<Assessment>> findAssessmentByWeek(@PathVariable Integer batchId,
 			@PathVariable Integer week) {
 		log.debug("Find assessment by week number " + week + " for batch " + batchId + " ");

--- a/caliber/src/main/java/com/revature/caliber/controllers/AssessmentController.java
+++ b/caliber/src/main/java/com/revature/caliber/controllers/AssessmentController.java
@@ -48,8 +48,8 @@ public class AssessmentController {
 	 */
 
 	/**
-	 * QC can no longer create assessment, trainer only function
-	 * Create assessment response entity.
+	 * QC can no longer create assessment, trainer only function Create assessment
+	 * response entity.
 	 *
 	 * @param assessment
 	 *            the assessment
@@ -95,7 +95,7 @@ public class AssessmentController {
 	public ResponseEntity<Assessment> updateAssessment(@Valid @RequestBody Assessment assessment) {
 		log.info("Updating assessment: " + assessment);
 		assessmentService.update(assessment);
-		return new ResponseEntity<>(assessment,HttpStatus.OK);
+		return new ResponseEntity<>(assessment, HttpStatus.OK);
 	}
 
 	/**
@@ -114,6 +114,5 @@ public class AssessmentController {
 		List<Assessment> assessments = assessmentService.findAssessmentByWeek(batchId, week);
 		return new ResponseEntity<>(assessments, HttpStatus.OK);
 	}
-	
-}
 
+}

--- a/caliber/src/main/java/com/revature/caliber/controllers/AssessmentController.java
+++ b/caliber/src/main/java/com/revature/caliber/controllers/AssessmentController.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -55,6 +56,7 @@ public class AssessmentController {
 	 */
 	@RequestMapping(value = "/trainer/assessment/create", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
+	@PreAuthorize("hasAnyRole('VP', 'TRAINER')")
 	public ResponseEntity<Void> createAssessment(@Valid @RequestBody Assessment assessment) {
 		log.info("Creating assessment: " + assessment);
 		assessmentService.save(assessment);
@@ -70,6 +72,7 @@ public class AssessmentController {
 	 */
 	@RequestMapping(value = "/trainer/assessment/delete/{id}", method = RequestMethod.DELETE, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
+	@PreAuthorize("hasAnyRole('VP', 'TRAINER')")
 	public ResponseEntity<Void> deleteAssessment(@PathVariable Long id) {
 		log.info("Deleting assessment: " + id);
 		Assessment assessment = new Assessment();
@@ -87,6 +90,7 @@ public class AssessmentController {
 	 */
 	@RequestMapping(value = "/trainer/assessment/update", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
+	@PreAuthorize("hasAnyRole('VP', 'TRAINER')")
 	public ResponseEntity<Assessment> updateAssessment(@Valid @RequestBody Assessment assessment) {
 		log.info("Updating assessment: " + assessment);
 		assessmentService.update(assessment);
@@ -102,6 +106,7 @@ public class AssessmentController {
 	 */
 	@RequestMapping(value = "/trainer/assessment/{batchId}/{week}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
+	@PreAuthorize("hasAnyRole('VP', 'TRAINER')")
 	public ResponseEntity<List<Assessment>> findAssessmentByWeek(@PathVariable Integer batchId,
 			@PathVariable Integer week) {
 		log.debug("Find assessment by week number " + week + " for batch " + batchId + " ");

--- a/caliber/src/main/java/com/revature/caliber/controllers/BootController.java
+++ b/caliber/src/main/java/com/revature/caliber/controllers/BootController.java
@@ -109,7 +109,9 @@ public class BootController extends Helper {
 	}
 
 	@RequestMapping(value = "/home")
-	public String sendHome(){
+	public String sendHome(HttpServletResponse response, Authentication auth){
+		SalesforceUser a = (SalesforceUser) auth.getPrincipal();
+        response.addCookie(new Cookie ("role",a.getRole()));
 		return "index";
 	}
 

--- a/caliber/src/main/java/com/revature/caliber/controllers/BootController.java
+++ b/caliber/src/main/java/com/revature/caliber/controllers/BootController.java
@@ -56,8 +56,8 @@ public class BootController extends Helper {
 	}
 
 	/**
-	 * Gathers Salesforce user data, authorizes user to access Caliber. Forwards
-	 * to the landing page according to the user's role.
+	 * Gathers Salesforce user data, authorizes user to access Caliber. Forwards to
+	 * the landing page according to the user's role.
 	 *
 	 * @param servletRequest
 	 *            the servlet request
@@ -70,8 +70,8 @@ public class BootController extends Helper {
 	 *             the uri syntax exception
 	 */
 	@RequestMapping(value = "/caliber")
-	public String devHomePage(HttpServletRequest servletRequest, HttpServletResponse servletResponse,@ModelAttribute("salestoken") String salesTokenString, Model model)
-			throws IOException, URISyntaxException {
+	public String devHomePage(HttpServletRequest servletRequest, HttpServletResponse servletResponse,
+			@ModelAttribute("salestoken") String salesTokenString, Model model) throws IOException, URISyntaxException {
 		if (debug) {
 			// fake Salesforce User
 			SalesforceUser salesforceUser = new SalesforceUser();
@@ -101,15 +101,15 @@ public class BootController extends Helper {
 			authorize(jsonString, salesforceUser, servletResponse);
 			return "redirect:/home/";
 		} catch (AuthenticationCredentialsNotFoundException e) {
-			log.error("error thrown:" ,e);
+			log.error("error thrown:", e);
 			return "redirect:/";
 		}
 	}
 
 	@RequestMapping(value = "/home")
-	public String sendHome(HttpServletResponse response, Authentication auth){
+	public String sendHome(HttpServletResponse response, Authentication auth) {
 		SalesforceUser a = (SalesforceUser) auth.getPrincipal();
-        response.addCookie(new Cookie ("role",a.getRole()));
+		response.addCookie(new Cookie("role", a.getRole()));
 		return "index";
 	}
 
@@ -122,7 +122,7 @@ public class BootController extends Helper {
 	 */
 	private SalesforceToken getSalesforceToken(String token) throws IOException {
 		log.error("Checking for the salesforce token");
-		if (token!=null) {
+		if (token != null) {
 			log.error("Parse salesforce token from forwarded request: " + token);
 			return new ObjectMapper().readValue(token, SalesforceToken.class);
 		}
@@ -131,8 +131,8 @@ public class BootController extends Helper {
 	}
 
 	/**
-	 * Makes a request to Salesforce REST API to retrieve the authenticated
-	 * user's details
+	 * Makes a request to Salesforce REST API to retrieve the authenticated user's
+	 * details
 	 * 
 	 * @param servletRequest
 	 * @param salesforceToken
@@ -159,9 +159,8 @@ public class BootController extends Helper {
 
 	/**
 	 * Gets Caliber user from database (TRAINER table) and validates if provided
-	 * email is authorized to user Caliber. All authorized Caliber users must
-	 * exist as a TRAINER record with email matching that of Salesforce user
-	 * email.
+	 * email is authorized to user Caliber. All authorized Caliber users must exist
+	 * as a TRAINER record with email matching that of Salesforce user email.
 	 * 
 	 * @param servletRequest
 	 * @param email
@@ -189,9 +188,9 @@ public class BootController extends Helper {
 	}
 
 	/**
-	 * Parses a Json String containing TRAINER bean. Authorize the user with
-	 * Caliber and store their PreAuthenticatedAuthenticationToken in session.
-	 * Adds convenience 'role' cookie for AngularJS consumption.
+	 * Parses a Json String containing TRAINER bean. Authorize the user with Caliber
+	 * and store their PreAuthenticatedAuthenticationToken in session. Adds
+	 * convenience 'role' cookie for AngularJS consumption.
 	 * 
 	 * @param jsonString
 	 * @param salesforceUser

--- a/caliber/src/main/java/com/revature/caliber/controllers/CategoryController.java
+++ b/caliber/src/main/java/com/revature/caliber/controllers/CategoryController.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,6 +34,7 @@ public class CategoryController {
 	}
 
 	@RequestMapping(value = "/category/all", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	@PreAuthorize("hasRole('VP')")
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
 	public ResponseEntity<List<Category>> findAllCategories() {
 		log.debug("Getting categories");
@@ -42,6 +44,7 @@ public class CategoryController {
 
 	@RequestMapping(value = "/vp/category", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
+	@PreAuthorize("hasRole('VP')")
 	public ResponseEntity<List<Category>> findAll() {
 		log.debug("Getting categories");
 		List<Category> categories = categoryService.findAll();
@@ -50,6 +53,7 @@ public class CategoryController {
 
 	@RequestMapping(value = "/category/{id}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
+	@PreAuthorize("hasRole('VP')")
 	public ResponseEntity<Category> findCategoryById(@PathVariable int id) {
 		log.debug("Getting category: " + id);
 		Category category = categoryService.findCategory(id);
@@ -58,6 +62,7 @@ public class CategoryController {
 
 	@RequestMapping(value = "/vp/category/update", method = RequestMethod.PUT, consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
+	@PreAuthorize("hasRole('VP')")
 	public ResponseEntity<Category> updateCategory(@Valid @RequestBody Category category) {
 		categoryService.updateCategory(category);
 		return new ResponseEntity<>(category, HttpStatus.OK);
@@ -65,6 +70,7 @@ public class CategoryController {
 
 	@RequestMapping(value = "/vp/category", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
+	@PreAuthorize("hasRole('VP')")
 	public ResponseEntity<Category> saveCategory(@Valid @RequestBody Category category) {
 		categoryService.saveCategory(category);
 		return new ResponseEntity<>(category, HttpStatus.CREATED);

--- a/caliber/src/main/java/com/revature/caliber/controllers/CategoryController.java
+++ b/caliber/src/main/java/com/revature/caliber/controllers/CategoryController.java
@@ -34,7 +34,7 @@ public class CategoryController {
 	}
 
 	@RequestMapping(value = "/category/all", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	@PreAuthorize("hasRole('VP')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
 	public ResponseEntity<List<Category>> findAllCategories() {
 		log.debug("Getting categories");
@@ -44,7 +44,7 @@ public class CategoryController {
 
 	@RequestMapping(value = "/vp/category", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
-	@PreAuthorize("hasRole('VP')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public ResponseEntity<List<Category>> findAll() {
 		log.debug("Getting categories");
 		List<Category> categories = categoryService.findAll();
@@ -53,7 +53,7 @@ public class CategoryController {
 
 	@RequestMapping(value = "/category/{id}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
-	@PreAuthorize("hasRole('VP')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public ResponseEntity<Category> findCategoryById(@PathVariable int id) {
 		log.debug("Getting category: " + id);
 		Category category = categoryService.findCategory(id);

--- a/caliber/src/main/java/com/revature/caliber/controllers/CategoryController.java
+++ b/caliber/src/main/java/com/revature/caliber/controllers/CategoryController.java
@@ -34,7 +34,7 @@ public class CategoryController {
 	}
 
 	@RequestMapping(value = "/category/all", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
 	public ResponseEntity<List<Category>> findAllCategories() {
 		log.debug("Getting categories");
@@ -44,7 +44,7 @@ public class CategoryController {
 
 	@RequestMapping(value = "/vp/category", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
-	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public ResponseEntity<List<Category>> findAll() {
 		log.debug("Getting categories");
 		List<Category> categories = categoryService.findAll();
@@ -53,7 +53,7 @@ public class CategoryController {
 
 	@RequestMapping(value = "/category/{id}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
-	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public ResponseEntity<Category> findCategoryById(@PathVariable int id) {
 		log.debug("Getting category: " + id);
 		Category category = categoryService.findCategory(id);

--- a/caliber/src/main/java/com/revature/caliber/controllers/EvaluationController.java
+++ b/caliber/src/main/java/com/revature/caliber/controllers/EvaluationController.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -52,7 +53,7 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/trainer/grade/create", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE)
-	// @PreAuthorize("hasAnyRole('TRAINER, QC, VP')")
+	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public ResponseEntity<Grade> createGrade(@Valid @RequestBody Grade grade) {
 		log.info("Saving grade: " + grade);
 		evaluationService.save(grade);
@@ -66,7 +67,7 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/trainer/grade/update", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE)
-	// @PreAuthorize("hasAnyRole('TRAINER, QC, VP')")
+	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public ResponseEntity<Void> updateGrade(@Valid @RequestBody Grade grade) {
 		log.info("Updating grade: " + grade);
 		evaluationService.update(grade);
@@ -83,7 +84,7 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/vp/grade/all", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	// @PreAuthorize("hasRole('VP')")
+	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public List<Grade> findAll() {
 		log.info("Finding all grades");
 		return evaluationService.findAllGrades();
@@ -97,7 +98,7 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/all/grades/assessment/{assessmentId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	// @PreAuthorize("hasAnyRole('TRAINER, QC, VP')")
+	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public List<Grade> findByAssessment(@PathVariable Long assessmentId) {
 		log.info("Finding grades for assessment: " + assessmentId);
 		return evaluationService.findGradesByAssessment(assessmentId);
@@ -111,7 +112,7 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/all/grade/trainee/{traineeId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	// @PreAuthorize("hasAnyRole('TRAINER, QC, VP')")
+	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public List<Grade> findByTrainee(@PathVariable Integer traineeId) {
 		log.info("Finding all grades for trainee: " + traineeId);
 		return evaluationService.findGradesByTrainee(traineeId);
@@ -125,7 +126,7 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/all/grade/batch/{batchId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	// @PreAuthorize("hasAnyRole('TRAINER, QC, VP')")
+	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public List<Grade> findByBatch(@PathVariable Integer batchId) {
 		log.info("Finding all grades for batch: " + batchId);
 		return evaluationService.findGradesByBatch(batchId);
@@ -139,7 +140,7 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/all/grade/category/{categoryId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	// @PreAuthorize("hasAnyRole('TRAINER, QC, VP')")
+	 @PreAuthorize("hasAnyRole('VP', 'QC')")
 	public List<Grade> findByCategory(@PathVariable Integer categoryId) {
 		log.info("Finding all grades for category: " + categoryId);
 		return evaluationService.findGradesByCategory(categoryId);
@@ -155,7 +156,7 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/all/grades/batch/{batchId}/week/{week}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	// @PreAuthorize("hasAnyRole('TRAINER, QC, VP')")
+	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public ResponseEntity<Map<Integer, List<Grade>>> findByWeek(@PathVariable Integer batchId,
 			@PathVariable Integer week) {
 		log.info(FINDING_WEEK + week + " grades for batch: " + batchId);
@@ -173,7 +174,7 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/all/grade/trainer/{trainerId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	// @PreAuthorize("hasAnyRole('TRAINER, QC, VP')")
+	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public List<Grade> findByTrainer(@PathVariable Integer trainerId) {
 		log.info("Finding all grades for trainer: " + trainerId);
 		return evaluationService.findGradesByTrainer(trainerId);
@@ -193,7 +194,7 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/note/create", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE)
-	// @PreAuthorize("hasAnyRole('TRAINER, QC, VP')")
+	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public ResponseEntity<Integer> createNote(@Valid @RequestBody Note note) {
 		log.info("Creating note: " + note);
 		return new ResponseEntity<>(evaluationService.save(note), HttpStatus.CREATED);
@@ -206,7 +207,7 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/note/update", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE)
-	// @PreAuthorize("hasAnyRole('TRAINER, QC, VP')")
+	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public ResponseEntity<Note> updateNote(@Valid @RequestBody Note note) {
 		log.info("Updating note: " + note);
 		evaluationService.update(note);
@@ -227,7 +228,7 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/trainer/note/batch/{batchId}/{week}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	// @PreAuthorize("hasAnyRole('TRAINER, QC, VP')")
+	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public ResponseEntity<List<Note>> findBatchNotes(@PathVariable Integer batchId, @PathVariable Integer week) {
 		log.info(FINDING_WEEK + week + " batch notes for batch: " + batchId);
 		return new ResponseEntity<>(evaluationService.findBatchNotes(batchId, week), HttpStatus.OK);
@@ -241,7 +242,7 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/trainer/note/trainee/{batchId}/{week}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	//@PreAuthorize("hasAnyRole('TRAINER, QC, VP')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public ResponseEntity<List<Note>> findIndividualNotes(@PathVariable Integer batchId, @PathVariable Integer week) {
 		log.info(FINDING_WEEK + week + " individual notes for trainee: " + batchId); 
 		return new ResponseEntity<>(evaluationService.findIndividualNotes(batchId, week), HttpStatus.OK);
@@ -256,6 +257,7 @@ public class EvaluationController {
 	 * @return 
 	 */
 	@RequestMapping(value = "/trainer/note/trainee/{traineeId}/for/{week}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	@PreAuthorize("hasRole('VP', 'QC', 'TRAINER')")
 	public ResponseEntity<Note> findTraineeNote(@PathVariable Integer traineeId, @PathVariable Integer week) {
 		return new ResponseEntity<>(evaluationService.findTraineeNote(traineeId, week), HttpStatus.OK);
 	}
@@ -268,6 +270,7 @@ public class EvaluationController {
 	 * @return 
 	 */
 	@RequestMapping(value = "/qc/note/trainee/{traineeId}/for/{week}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	@PreAuthorize("hasAnyRole('VP', 'QC')")
 	public ResponseEntity<Note> findQCTraineeNote(@PathVariable Integer traineeId, @PathVariable Integer week) {
 		return new ResponseEntity<>(evaluationService.findQCTraineeNote(traineeId, week), HttpStatus.OK);
 	}
@@ -281,7 +284,7 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/qc/note/batch/{batchId}/{week}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	// @PreAuthorize("hasAnyRole('QC, VP')")
+	 @PreAuthorize("hasAnyRole('VP', 'QC')")
 	public ResponseEntity<Note> findQCBatchNotes(@PathVariable Integer batchId, @PathVariable Integer week) {
 		log.info(FINDING_WEEK + week + " QC batch notes for batch: " + batchId);
 		return new ResponseEntity<>(evaluationService.findQCBatchNotes(batchId, week), HttpStatus.OK);
@@ -293,7 +296,8 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/qc/note/trainee/{batchId}/{week}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<List<Note>> getAllQCTraineeNotes(@PathVariable Integer batchId, @PathVariable Integer week) {
+    @PreAuthorize("hasAnyRole('VP', 'QC')")
+	public ResponseEntity<List<Note>> getAllQCTraineeNotes(@PathVariable Integer batchId, @PathVariable Integer week) {
         log.info("Getting all trainee notes by QC");
         return new ResponseEntity<>(evaluationService.findAllQCTraineeNotes(batchId, week), HttpStatus.OK);
     }
@@ -304,7 +308,8 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/qc/note/trainee/{traineeId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<List<Note>> getAllQCTraineeOverallNotes(@PathVariable Integer traineeId) {
+    @PreAuthorize("hasAnyRole('VP', 'QC')")
+	public ResponseEntity<List<Note>> getAllQCTraineeOverallNotes(@PathVariable Integer traineeId) {
         log.info("Getting all trainee notes by QC for that trainee");
         return new ResponseEntity<>(evaluationService.findAllQCTraineeOverallNotes(traineeId), HttpStatus.OK);
     }
@@ -324,7 +329,7 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/vp/note/batch/{batchId}/{week}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	// @PreAuthorize("hasRole('VP')")
+	 @PreAuthorize("hasRole('VP')")
 	public ResponseEntity<List<Note>> findAllBatchNotes(@PathVariable Integer batchId, @PathVariable Integer week) {
 		log.info(FINDING_WEEK + week + " batch notes for batch: " + batchId);
 		return new ResponseEntity<>(evaluationService.findAllBatchNotes(batchId, week), HttpStatus.OK);
@@ -338,7 +343,7 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/vp/note/trainee/{traineeId}/{week}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	// @PreAuthorize("hasRole('VP')")
+	 @PreAuthorize("hasRole('VP')")
 	public ResponseEntity<List<Note>> findAllIndividualNotes(@PathVariable Integer traineeId,
 			@PathVariable Integer week) {
 		log.info("Finding all week " + week + " individual notes for trainee: " + traineeId);
@@ -346,6 +351,7 @@ public class EvaluationController {
 	}
 	
 	@RequestMapping(value="/all/notes/trainee/{traineeId}",method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	@PreAuthorize("hasRole('VP')")
 	public ResponseEntity<List<Note>> findAllTraineeNotes(@PathVariable Integer traineeId){
 		return new ResponseEntity<>(evaluationService.findAllIndividualNotesOverall(traineeId),HttpStatus.OK);
 	}

--- a/caliber/src/main/java/com/revature/caliber/controllers/EvaluationController.java
+++ b/caliber/src/main/java/com/revature/caliber/controllers/EvaluationController.java
@@ -140,7 +140,7 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/all/grade/category/{categoryId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	 @PreAuthorize("hasAnyRole('VP', 'QC')")
+	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public List<Grade> findByCategory(@PathVariable Integer categoryId) {
 		log.info("Finding all grades for category: " + categoryId);
 		return evaluationService.findGradesByCategory(categoryId);
@@ -257,7 +257,7 @@ public class EvaluationController {
 	 * @return 
 	 */
 	@RequestMapping(value = "/trainer/note/trainee/{traineeId}/for/{week}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	@PreAuthorize("hasRole('VP', 'QC', 'TRAINER')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public ResponseEntity<Note> findTraineeNote(@PathVariable Integer traineeId, @PathVariable Integer week) {
 		return new ResponseEntity<>(evaluationService.findTraineeNote(traineeId, week), HttpStatus.OK);
 	}

--- a/caliber/src/main/java/com/revature/caliber/controllers/EvaluationController.java
+++ b/caliber/src/main/java/com/revature/caliber/controllers/EvaluationController.java
@@ -33,7 +33,7 @@ public class EvaluationController {
 
 	private static final Logger log = Logger.getLogger(EvaluationController.class);
 	private EvaluationService evaluationService;
-	private static final String FINDING_WEEK = "Finding week "; 
+	private static final String FINDING_WEEK = "Finding week ";
 
 	@Autowired
 	public void setEvaluationService(EvaluationService evaluationService) {
@@ -54,11 +54,11 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/trainer/grade/create", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE)
-	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public ResponseEntity<Grade> createGrade(@Valid @RequestBody Grade grade) {
 		log.info("Saving grade: " + grade);
 		evaluationService.save(grade);
-		return new ResponseEntity<>(grade,HttpStatus.CREATED);
+		return new ResponseEntity<>(grade, HttpStatus.CREATED);
 	}
 
 	/**
@@ -68,7 +68,7 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/trainer/grade/update", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE)
-	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public ResponseEntity<Void> updateGrade(@Valid @RequestBody Grade grade) {
 		log.info("Updating grade: " + grade);
 		evaluationService.update(grade);
@@ -76,30 +76,29 @@ public class EvaluationController {
 	}
 
 	/**
-	 * Returns absolutely all grades for only the most coarsely-grained
-	 * reporting. Useful for feeding data into application for statistical
-	 * analyses, such as regression analysis, calculating mean, and finding
-	 * average ;)
+	 * Returns absolutely all grades for only the most coarsely-grained reporting.
+	 * Useful for feeding data into application for statistical analyses, such as
+	 * regression analysis, calculating mean, and finding average ;)
 	 * 
 	 * @param traineeId
 	 * @return
 	 */
 	@RequestMapping(value = "/vp/grade/all", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public List<Grade> findAll() {
 		log.info("Finding all grades");
 		return evaluationService.findAllGrades();
 	}
 
 	/**
-	 * Returns grades for all trainees that took a particular assignment. Great
-	 * for finding average/median/highest/lowest grades for a test
+	 * Returns grades for all trainees that took a particular assignment. Great for
+	 * finding average/median/highest/lowest grades for a test
 	 * 
 	 * @param assessmentId
 	 * @return
 	 */
 	@RequestMapping(value = "/all/grades/assessment/{assessmentId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public List<Grade> findByAssessment(@PathVariable Long assessmentId) {
 		log.info("Finding grades for assessment: " + assessmentId);
 		return evaluationService.findGradesByAssessment(assessmentId);
@@ -113,51 +112,50 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/all/grade/trainee/{traineeId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public List<Grade> findByTrainee(@PathVariable Integer traineeId) {
 		log.info("Finding all grades for trainee: " + traineeId);
 		return evaluationService.findGradesByTrainee(traineeId);
 	}
 
 	/**
-	 * Returns all grades for a batch. Useful for calculating coarsely-grained
-	 * data for reporting.
+	 * Returns all grades for a batch. Useful for calculating coarsely-grained data
+	 * for reporting.
 	 * 
 	 * @param batchId
 	 * @return
 	 */
 	@RequestMapping(value = "/all/grade/batch/{batchId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public List<Grade> findByBatch(@PathVariable Integer batchId) {
 		log.info("Finding all grades for batch: " + batchId);
 		return evaluationService.findGradesByBatch(batchId);
 	}
 
 	/**
-	 * Returns all grades for a category. Useful for improving performance time
-	 * of company-wide reporting
+	 * Returns all grades for a category. Useful for improving performance time of
+	 * company-wide reporting
 	 * 
 	 * @param batchId
 	 * @return
 	 */
 	@RequestMapping(value = "/all/grade/category/{categoryId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public List<Grade> findByCategory(@PathVariable Integer categoryId) {
 		log.info("Finding all grades for category: " + categoryId);
 		return evaluationService.findGradesByCategory(categoryId);
 	}
 
 	/**
-	 * Returns grades for all trainees in the batch on a given week. Used to
-	 * load grade data onto the input spreadsheet, as well as tabular/chart
-	 * reporting.
+	 * Returns grades for all trainees in the batch on a given week. Used to load
+	 * grade data onto the input spreadsheet, as well as tabular/chart reporting.
 	 * 
 	 * @param batchId
 	 * @param week
 	 * @return
 	 */
 	@RequestMapping(value = "/all/grades/batch/{batchId}/week/{week}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public ResponseEntity<Map<Integer, List<Grade>>> findByWeek(@PathVariable Integer batchId,
 			@PathVariable Integer week) {
 		log.info(FINDING_WEEK + week + " grades for batch: " + batchId);
@@ -166,16 +164,15 @@ public class EvaluationController {
 	}
 
 	/**
-	 * Returns all grades issued as acting trainer or cotrainer to a batch.
-	 * Useful for calculating coarsely-grained data for reporting. Potential
-	 * refactor here.. this queries database twice where we could find way to
-	 * simply join.
+	 * Returns all grades issued as acting trainer or cotrainer to a batch. Useful
+	 * for calculating coarsely-grained data for reporting. Potential refactor
+	 * here.. this queries database twice where we could find way to simply join.
 	 * 
 	 * @param trainerId
 	 * @return
 	 */
 	@RequestMapping(value = "/all/grade/trainer/{trainerId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public List<Grade> findByTrainer(@PathVariable Integer trainerId) {
 		log.info("Finding all grades for trainer: " + trainerId);
 		return evaluationService.findGradesByTrainer(trainerId);
@@ -195,7 +192,7 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/note/create", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE)
-	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public ResponseEntity<Integer> createNote(@Valid @RequestBody Note note) {
 		log.info("Creating note: " + note);
 		return new ResponseEntity<>(evaluationService.save(note), HttpStatus.CREATED);
@@ -208,11 +205,11 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/note/update", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE)
-	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public ResponseEntity<Note> updateNote(@Valid @RequestBody Note note) {
 		log.info("Updating note: " + note);
 		evaluationService.update(note);
-		return new ResponseEntity<>(note,HttpStatus.CREATED);
+		return new ResponseEntity<>(note, HttpStatus.CREATED);
 	}
 
 	/*
@@ -229,7 +226,7 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/trainer/note/batch/{batchId}/{week}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public ResponseEntity<List<Note>> findBatchNotes(@PathVariable Integer batchId, @PathVariable Integer week) {
 		log.info(FINDING_WEEK + week + " batch notes for batch: " + batchId);
 		return new ResponseEntity<>(evaluationService.findBatchNotes(batchId, week), HttpStatus.OK);
@@ -245,38 +242,36 @@ public class EvaluationController {
 	@RequestMapping(value = "/trainer/note/trainee/{batchId}/{week}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public ResponseEntity<List<Note>> findIndividualNotes(@PathVariable Integer batchId, @PathVariable Integer week) {
-		log.info(FINDING_WEEK + week + " individual notes for trainee: " + batchId); 
+		log.info(FINDING_WEEK + week + " individual notes for trainee: " + batchId);
 		return new ResponseEntity<>(evaluationService.findIndividualNotes(batchId, week), HttpStatus.OK);
 	}
 
-	
 	/**
-	 * FIND TRAINEE NOTE FOR THE WEEK 
+	 * FIND TRAINEE NOTE FOR THE WEEK
 	 * 
 	 * @param trainee
 	 * @param week
-	 * @return 
+	 * @return
 	 */
 	@RequestMapping(value = "/trainer/note/trainee/{traineeId}/for/{week}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public ResponseEntity<Note> findTraineeNote(@PathVariable Integer traineeId, @PathVariable Integer week) {
 		return new ResponseEntity<>(evaluationService.findTraineeNote(traineeId, week), HttpStatus.OK);
 	}
-	
+
 	/**
-	 * FIND TRAINEE NOTE FOR THE WEEK(Michael) 
+	 * FIND TRAINEE NOTE FOR THE WEEK(Michael)
 	 * 
 	 * @param QCtrainee
 	 * @param week
-	 * @return 
+	 * @return
 	 */
 	@RequestMapping(value = "/qc/note/trainee/{traineeId}/for/{week}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	@PreAuthorize("hasAnyRole('VP', 'QC', 'STAGING')")
 	public ResponseEntity<Note> findQCTraineeNote(@PathVariable Integer traineeId, @PathVariable Integer week) {
 		return new ResponseEntity<>(evaluationService.findQCTraineeNote(traineeId, week), HttpStatus.OK);
 	}
-	
-	
+
 	/**
 	 * FIND THE WEEKLY QC BATCH NOTE FOR THE WEEK(NOT FOR TRAINERS)
 	 * 
@@ -285,7 +280,7 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/qc/note/batch/{batchId}/{week}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	 @PreAuthorize("hasAnyRole('VP', 'QC', 'STAGING')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'STAGING')")
 	public ResponseEntity<Note> findQCBatchNotes(@PathVariable Integer batchId, @PathVariable Integer week) {
 		log.info(FINDING_WEEK + week + " QC batch notes for batch: " + batchId);
 		return new ResponseEntity<>(evaluationService.findQCBatchNotes(batchId, week), HttpStatus.OK);
@@ -297,24 +292,24 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/qc/note/trainee/{batchId}/{week}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-    @PreAuthorize("hasAnyRole('VP', 'QC', 'STAGING')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'STAGING')")
 	public ResponseEntity<List<Note>> getAllQCTraineeNotes(@PathVariable Integer batchId, @PathVariable Integer week) {
-        log.info("Getting all trainee notes by QC");
-        return new ResponseEntity<>(evaluationService.findAllQCTraineeNotes(batchId, week), HttpStatus.OK);
-    }
-	
+		log.info("Getting all trainee notes by QC");
+		return new ResponseEntity<>(evaluationService.findAllQCTraineeNotes(batchId, week), HttpStatus.OK);
+	}
+
 	/**
 	 * Find all QC trainee notes in a batch
 	 * 
 	 * @return
 	 */
 	@RequestMapping(value = "/qc/note/trainee/{traineeId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-    @PreAuthorize("hasAnyRole('VP', 'QC', 'STAGING')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'STAGING')")
 	public ResponseEntity<List<Note>> getAllQCTraineeOverallNotes(@PathVariable Integer traineeId) {
-        log.info("Getting all trainee notes by QC for that trainee");
-        return new ResponseEntity<>(evaluationService.findAllQCTraineeOverallNotes(traineeId), HttpStatus.OK);
-    }
-	
+		log.info("Getting all trainee notes by QC for that trainee");
+		return new ResponseEntity<>(evaluationService.findAllQCTraineeOverallNotes(traineeId), HttpStatus.OK);
+	}
+
 	/*
 	 *******************************************************
 	 * TODO VP NOTE SERVICES
@@ -330,7 +325,7 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/vp/note/batch/{batchId}/{week}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	 @PreAuthorize("hasRole('VP')")
+	@PreAuthorize("hasRole('VP')")
 	public ResponseEntity<List<Note>> findAllBatchNotes(@PathVariable Integer batchId, @PathVariable Integer week) {
 		log.info(FINDING_WEEK + week + " batch notes for batch: " + batchId);
 		return new ResponseEntity<>(evaluationService.findAllBatchNotes(batchId, week), HttpStatus.OK);
@@ -344,16 +339,16 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/vp/note/trainee/{traineeId}/{week}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	 @PreAuthorize("hasRole('VP')")
+	@PreAuthorize("hasRole('VP')")
 	public ResponseEntity<List<Note>> findAllIndividualNotes(@PathVariable Integer traineeId,
 			@PathVariable Integer week) {
 		log.info("Finding all week " + week + " individual notes for trainee: " + traineeId);
 		return new ResponseEntity<>(evaluationService.findAllIndividualNotes(traineeId, week), HttpStatus.OK);
 	}
-	
-	@RequestMapping(value="/all/notes/trainee/{traineeId}",method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+
+	@RequestMapping(value = "/all/notes/trainee/{traineeId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	@PreAuthorize("hasRole('VP')")
-	public ResponseEntity<List<Note>> findAllTraineeNotes(@PathVariable Integer traineeId){
-		return new ResponseEntity<>(evaluationService.findAllIndividualNotesOverall(traineeId),HttpStatus.OK);
+	public ResponseEntity<List<Note>> findAllTraineeNotes(@PathVariable Integer traineeId) {
+		return new ResponseEntity<>(evaluationService.findAllIndividualNotesOverall(traineeId), HttpStatus.OK);
 	}
 }

--- a/caliber/src/main/java/com/revature/caliber/controllers/EvaluationController.java
+++ b/caliber/src/main/java/com/revature/caliber/controllers/EvaluationController.java
@@ -84,7 +84,7 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/vp/grade/all", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public List<Grade> findAll() {
 		log.info("Finding all grades");
 		return evaluationService.findAllGrades();
@@ -98,7 +98,7 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/all/grades/assessment/{assessmentId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public List<Grade> findByAssessment(@PathVariable Long assessmentId) {
 		log.info("Finding grades for assessment: " + assessmentId);
 		return evaluationService.findGradesByAssessment(assessmentId);
@@ -112,7 +112,7 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/all/grade/trainee/{traineeId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public List<Grade> findByTrainee(@PathVariable Integer traineeId) {
 		log.info("Finding all grades for trainee: " + traineeId);
 		return evaluationService.findGradesByTrainee(traineeId);
@@ -126,7 +126,7 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/all/grade/batch/{batchId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public List<Grade> findByBatch(@PathVariable Integer batchId) {
 		log.info("Finding all grades for batch: " + batchId);
 		return evaluationService.findGradesByBatch(batchId);
@@ -140,7 +140,7 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/all/grade/category/{categoryId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public List<Grade> findByCategory(@PathVariable Integer categoryId) {
 		log.info("Finding all grades for category: " + categoryId);
 		return evaluationService.findGradesByCategory(categoryId);
@@ -156,7 +156,7 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/all/grades/batch/{batchId}/week/{week}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public ResponseEntity<Map<Integer, List<Grade>>> findByWeek(@PathVariable Integer batchId,
 			@PathVariable Integer week) {
 		log.info(FINDING_WEEK + week + " grades for batch: " + batchId);
@@ -174,7 +174,7 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/all/grade/trainer/{trainerId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public List<Grade> findByTrainer(@PathVariable Integer trainerId) {
 		log.info("Finding all grades for trainer: " + trainerId);
 		return evaluationService.findGradesByTrainer(trainerId);
@@ -228,7 +228,7 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/trainer/note/batch/{batchId}/{week}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	 @PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public ResponseEntity<List<Note>> findBatchNotes(@PathVariable Integer batchId, @PathVariable Integer week) {
 		log.info(FINDING_WEEK + week + " batch notes for batch: " + batchId);
 		return new ResponseEntity<>(evaluationService.findBatchNotes(batchId, week), HttpStatus.OK);
@@ -242,7 +242,7 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/trainer/note/trainee/{batchId}/{week}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public ResponseEntity<List<Note>> findIndividualNotes(@PathVariable Integer batchId, @PathVariable Integer week) {
 		log.info(FINDING_WEEK + week + " individual notes for trainee: " + batchId); 
 		return new ResponseEntity<>(evaluationService.findIndividualNotes(batchId, week), HttpStatus.OK);
@@ -257,7 +257,7 @@ public class EvaluationController {
 	 * @return 
 	 */
 	@RequestMapping(value = "/trainer/note/trainee/{traineeId}/for/{week}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public ResponseEntity<Note> findTraineeNote(@PathVariable Integer traineeId, @PathVariable Integer week) {
 		return new ResponseEntity<>(evaluationService.findTraineeNote(traineeId, week), HttpStatus.OK);
 	}
@@ -270,7 +270,7 @@ public class EvaluationController {
 	 * @return 
 	 */
 	@RequestMapping(value = "/qc/note/trainee/{traineeId}/for/{week}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	@PreAuthorize("hasAnyRole('VP', 'QC')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'STAGING')")
 	public ResponseEntity<Note> findQCTraineeNote(@PathVariable Integer traineeId, @PathVariable Integer week) {
 		return new ResponseEntity<>(evaluationService.findQCTraineeNote(traineeId, week), HttpStatus.OK);
 	}
@@ -284,7 +284,7 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/qc/note/batch/{batchId}/{week}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	 @PreAuthorize("hasAnyRole('VP', 'QC')")
+	 @PreAuthorize("hasAnyRole('VP', 'QC', 'STAGING')")
 	public ResponseEntity<Note> findQCBatchNotes(@PathVariable Integer batchId, @PathVariable Integer week) {
 		log.info(FINDING_WEEK + week + " QC batch notes for batch: " + batchId);
 		return new ResponseEntity<>(evaluationService.findQCBatchNotes(batchId, week), HttpStatus.OK);
@@ -296,7 +296,7 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/qc/note/trainee/{batchId}/{week}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-    @PreAuthorize("hasAnyRole('VP', 'QC')")
+    @PreAuthorize("hasAnyRole('VP', 'QC', 'STAGING')")
 	public ResponseEntity<List<Note>> getAllQCTraineeNotes(@PathVariable Integer batchId, @PathVariable Integer week) {
         log.info("Getting all trainee notes by QC");
         return new ResponseEntity<>(evaluationService.findAllQCTraineeNotes(batchId, week), HttpStatus.OK);
@@ -308,7 +308,7 @@ public class EvaluationController {
 	 * @return
 	 */
 	@RequestMapping(value = "/qc/note/trainee/{traineeId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-    @PreAuthorize("hasAnyRole('VP', 'QC')")
+    @PreAuthorize("hasAnyRole('VP', 'QC', 'STAGING')")
 	public ResponseEntity<List<Note>> getAllQCTraineeOverallNotes(@PathVariable Integer traineeId) {
         log.info("Getting all trainee notes by QC for that trainee");
         return new ResponseEntity<>(evaluationService.findAllQCTraineeOverallNotes(traineeId), HttpStatus.OK);

--- a/caliber/src/main/java/com/revature/caliber/controllers/PDFController.java
+++ b/caliber/src/main/java/com/revature/caliber/controllers/PDFController.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -26,6 +27,7 @@ public class PDFController {
 	}
 
 	@RequestMapping(value = "/report/generate", method = RequestMethod.POST)
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public HttpEntity<byte[]> generate(
 			@RequestParam(name = "title", value = "title", defaultValue = "Performance at a Glance") String title,
 			@RequestBody String html) {

--- a/caliber/src/main/java/com/revature/caliber/controllers/ReportingController.java
+++ b/caliber/src/main/java/com/revature/caliber/controllers/ReportingController.java
@@ -50,7 +50,7 @@ public class ReportingController {
 	 */
 
 	@RequestMapping(value = "/all/reports/compare/skill/{skill}/training/{training}/date/{startDate}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	@PreAuthorize("hasAnyRole('VP', 'QC')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public ResponseEntity<Double> getBatchComparisonAvg(@PathVariable String skill, @PathVariable String training,
 			@PathVariable Date startDate) {
 		log.info("YAYAYAYAYAYAYYAYAYAYAYAYAYAYAYAYATEZXRDCYTFUVGBJHLNKJSFSD " + startDate + skill + training);

--- a/caliber/src/main/java/com/revature/caliber/controllers/ReportingController.java
+++ b/caliber/src/main/java/com/revature/caliber/controllers/ReportingController.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -49,6 +50,7 @@ public class ReportingController {
 	 */
 
 	@RequestMapping(value = "/all/reports/compare/skill/{skill}/training/{training}/date/{startDate}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	@PreAuthorize("hasAnyRole('VP', 'QC')")
 	public ResponseEntity<Double> getBatchComparisonAvg(@PathVariable String skill, @PathVariable String training,
 			@PathVariable Date startDate) {
 		log.info("YAYAYAYAYAYAYYAYAYAYAYAYAYAYAYAYATEZXRDCYTFUVGBJHLNKJSFSD " + startDate + skill + training);
@@ -62,6 +64,7 @@ public class ReportingController {
 	 *******************************************************
 	 */
 	@RequestMapping(value = "/all/reports/batch/{batchId}/week/{weekId}/pie", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public ResponseEntity<Map<QCStatus, Integer>> getBatchWeekPieChart(@PathVariable Integer batchId,
 			@PathVariable Integer weekId) {
 		log.info("getBatchWeekPieChart   ===>   /all/reports/batch/{batchId}/week/{weekId}/pie");
@@ -69,6 +72,7 @@ public class ReportingController {
 	}
 
 	@RequestMapping(value = "/all/reports/batch/{batchId}/pie", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public ResponseEntity<Map<QCStatus, Integer>> getPieChartCurrentWeekQCStatus(@PathVariable Integer batchId) {
 		log.info("getPieChartCurrentWeekQCStatus ===> /all/reports/batch/{batchId}/week/pie");
 		try {
@@ -87,6 +91,7 @@ public class ReportingController {
 	 *******************************************************
 	 */
 	@RequestMapping(value = "/all/reports/batch/week/stacked-bar-current-week", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	@PreAuthorize("hasAnyRole('VP', 'QC')")
 	public ResponseEntity<Map<String, Map<QCStatus, Integer>>> getAllBatchesCurrentWeekQCStackedBarChart() {
 		log.info("getAllBatchesCurrentWeekQCStats   ===>   /all/reports/batch/week/stacked-bar-current-week");
 		return new ResponseEntity<>(reportingService.getAllBatchesCurrentWeekQCStackedBarChart(), HttpStatus.OK);
@@ -98,6 +103,7 @@ public class ReportingController {
 	 *******************************************************
 	 */
 	@RequestMapping(value = "/all/reports/batch/{batchId}/week/{week}/bar-batch-week-avg", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public ResponseEntity<Map<String, Double[]>> getBatchWeekAvgBarChart(@PathVariable int batchId,
 			@PathVariable int week) {
 		log.info("getBatchWeekAvgBarChart   ===>   /all/reports/batch/{batchId}/week/{week}/bar-batch-week-avg");
@@ -105,6 +111,7 @@ public class ReportingController {
 	}
 
 	@RequestMapping(value = "/all/reports/batch/{batchId}/week/{week}/bar-batch-weekly-sorted", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public ResponseEntity<Map<String, Double>> getBatchWeekSortedBarChart(@PathVariable int batchId,
 			@PathVariable int week) {
 		log.info("getBatchWeekAvgBarChart   ===>   /all/reports/batch/{batchId}/week/{week}/bar-batch-week-avg");
@@ -112,6 +119,7 @@ public class ReportingController {
 	}
 
 	@RequestMapping(value = "/all/reports/batch/{batchId}/overall/trainee/{traineeId}/bar-batch-overall-trainee", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public ResponseEntity<Map<String, Double[]>> getBatchOverallTraineeBarChart(@PathVariable Integer batchId,
 			@PathVariable Integer traineeId) {
 		log.info(
@@ -120,12 +128,14 @@ public class ReportingController {
 	}
 
 	@RequestMapping(value = "/all/reports/batch/{batchId}/overall/bar-batch-overall", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public ResponseEntity<Map<String, Double>> getBatchOverallBarChart(@PathVariable Integer batchId) {
 		log.info("getBatchOverallBarChart   ===>   /all/reports/batch/{batchId}/overall/bar-batch-overall");
 		return new ResponseEntity<>(reportingService.getBatchOverallBarChart(batchId), HttpStatus.OK);
 	}
 
 	@RequestMapping(value = "/all/reports/batch/{batchId}/week/{weekId}/trainee/{traineeId}/bar-batch-week-trainee", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public ResponseEntity<Map<String, Double[]>> getBatchWeekTraineeBarChart(@PathVariable Integer batchId,
 			@PathVariable Integer weekId, @PathVariable Integer traineeId) {
 		log.info(
@@ -140,6 +150,7 @@ public class ReportingController {
 	 *******************************************************
 	 */
 	@RequestMapping(value = "/all/reports/batch/{batchId}/week/{week}/trainee/{traineeId}/line-trainee-up-to-week", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public ResponseEntity<Map<Integer, Double[]>> getTraineeUpToWeekLineChart(@PathVariable int batchId,
 			@PathVariable int week, @PathVariable int traineeId) {
 		log.info(
@@ -149,6 +160,7 @@ public class ReportingController {
 	}
 
 	@RequestMapping(value = "/all/reports/batch/{batchId}/overall/trainee/{traineeId}/line-trainee-overall", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public ResponseEntity<Map<Integer, Double[]>> getTraineeOverallLineChart(@PathVariable Integer batchId,
 			@PathVariable Integer traineeId) {
 		log.info(
@@ -157,12 +169,14 @@ public class ReportingController {
 	}
 
 	@RequestMapping(value = "/all/reports/batch/{batchId}/overall/line-batch-overall", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public ResponseEntity<Map<Integer, Double>> getBatchOverallLineChart(@PathVariable int batchId) {
 		log.info("getBatchOverallLineChart   ===>   /all/reports/batch/{batchId}/overall/line-batch-overall");
 		return new ResponseEntity<>(reportingService.getBatchOverallLineChart(batchId), HttpStatus.OK);
 	}
 
 	@RequestMapping(value = "/all/reports/dashboard", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	@PreAuthorize("hasAnyRole('VP', 'QC')")
 	public ResponseEntity<Map<String, Map<Integer, Double>>> getCurrentBatchesLineChart() {
 		log.info("getCurrentBatchesLineChart   ===>  /all/reports/dashboard");
 		return new ResponseEntity<>(reportingService.getAllCurrentBatchesLineChart(), HttpStatus.OK);
@@ -175,6 +189,7 @@ public class ReportingController {
 	 */
 
 	@RequestMapping(value = "/all/reports/week/{week}/trainee/{traineeId}/radar-trainee-up-to-week", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public ResponseEntity<Map<String, Double>> getTraineeUpToWeekRadarChart(@PathVariable Integer traineeId,
 			@PathVariable Integer week) {
 		log.info(
@@ -183,18 +198,21 @@ public class ReportingController {
 	}
 
 	@RequestMapping(value = "/all/reports/trainee/{traineeId}/radar-trainee-overall", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public ResponseEntity<Map<String, Double>> getTraineeOverallRadarChart(@PathVariable Integer traineeId) {
 		log.info("getTraineeOverallRadarChart   ===>   /all/reports/trainee/{traineeId}/radar-trainee-overall");
 		return new ResponseEntity<>(reportingService.getTraineeOverallRadarChart(traineeId), HttpStatus.OK);
 	}
 
 	@RequestMapping(value = "/all/reports/batch/{batchId}/overall/radar-batch-overall", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public ResponseEntity<Map<String, Double>> getBatchOverallRadarChart(@PathVariable Integer batchId) {
 		log.info("getBatchOverallRadarChart   ===>   /all/reports/batch/{batchId}/overall/radar-batch-overall");
 		return new ResponseEntity<>(reportingService.getBatchOverallRadarChart(batchId), HttpStatus.OK);
 	}
 
 	@RequestMapping(value = "/all/reports/batch/{batchId}/radar-batch-all-trainees", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public ResponseEntity<Map<String, Map<String, Double>>> getBatchAllTraineesRadarChart(
 			@PathVariable Integer batchId) {
 		log.info("getBatchOverallRadarChart   ===>   /all/reports/batch/{batchId}/overall/radar-batch-overall");
@@ -207,12 +225,14 @@ public class ReportingController {
 	 *******************************************************
 	 */
 	@RequestMapping(value = "/all/assessments/average/{batchId}/{week}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public ResponseEntity<Double> getBatchWeekAverageValue(@PathVariable Integer batchId, @PathVariable Integer week) {
 		log.info("getBatchWeekAverageValue   ===>   /all/reports/batch/{batchId}/overall/line-batch-overall");
 		return new ResponseEntity<>(reportingService.getAvgBatchWeekValue(batchId, week), HttpStatus.OK);
 	}
 
 	@RequestMapping(value = "/all/assessments/categories/batch/{batchId}/week/{week}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public ResponseEntity<Set<String>> getTechnologiesForTheWeek(@PathVariable Integer batchId,
 			@PathVariable Integer week) {
 		log.info("getBatchWeekAverageValue   ===>   /all/reports/batch/{batchId}/overall/line-batch-overall");

--- a/caliber/src/main/java/com/revature/caliber/controllers/ReportingController.java
+++ b/caliber/src/main/java/com/revature/caliber/controllers/ReportingController.java
@@ -50,7 +50,7 @@ public class ReportingController {
 	 */
 
 	@RequestMapping(value = "/all/reports/compare/skill/{skill}/training/{training}/date/{startDate}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public ResponseEntity<Double> getBatchComparisonAvg(@PathVariable String skill, @PathVariable String training,
 			@PathVariable Date startDate) {
 		log.info("YAYAYAYAYAYAYYAYAYAYAYAYAYAYAYAYATEZXRDCYTFUVGBJHLNKJSFSD " + startDate + skill + training);
@@ -64,7 +64,7 @@ public class ReportingController {
 	 *******************************************************
 	 */
 	@RequestMapping(value = "/all/reports/batch/{batchId}/week/{weekId}/pie", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public ResponseEntity<Map<QCStatus, Integer>> getBatchWeekPieChart(@PathVariable Integer batchId,
 			@PathVariable Integer weekId) {
 		log.info("getBatchWeekPieChart   ===>   /all/reports/batch/{batchId}/week/{weekId}/pie");
@@ -72,7 +72,7 @@ public class ReportingController {
 	}
 
 	@RequestMapping(value = "/all/reports/batch/{batchId}/pie", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public ResponseEntity<Map<QCStatus, Integer>> getPieChartCurrentWeekQCStatus(@PathVariable Integer batchId) {
 		log.info("getPieChartCurrentWeekQCStatus ===> /all/reports/batch/{batchId}/week/pie");
 		try {
@@ -91,7 +91,7 @@ public class ReportingController {
 	 *******************************************************
 	 */
 	@RequestMapping(value = "/all/reports/batch/week/stacked-bar-current-week", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	@PreAuthorize("hasAnyRole('VP', 'QC')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'STAGING')")
 	public ResponseEntity<Map<String, Map<QCStatus, Integer>>> getAllBatchesCurrentWeekQCStackedBarChart() {
 		log.info("getAllBatchesCurrentWeekQCStats   ===>   /all/reports/batch/week/stacked-bar-current-week");
 		return new ResponseEntity<>(reportingService.getAllBatchesCurrentWeekQCStackedBarChart(), HttpStatus.OK);
@@ -103,7 +103,7 @@ public class ReportingController {
 	 *******************************************************
 	 */
 	@RequestMapping(value = "/all/reports/batch/{batchId}/week/{week}/bar-batch-week-avg", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public ResponseEntity<Map<String, Double[]>> getBatchWeekAvgBarChart(@PathVariable int batchId,
 			@PathVariable int week) {
 		log.info("getBatchWeekAvgBarChart   ===>   /all/reports/batch/{batchId}/week/{week}/bar-batch-week-avg");
@@ -111,7 +111,7 @@ public class ReportingController {
 	}
 
 	@RequestMapping(value = "/all/reports/batch/{batchId}/week/{week}/bar-batch-weekly-sorted", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public ResponseEntity<Map<String, Double>> getBatchWeekSortedBarChart(@PathVariable int batchId,
 			@PathVariable int week) {
 		log.info("getBatchWeekAvgBarChart   ===>   /all/reports/batch/{batchId}/week/{week}/bar-batch-week-avg");
@@ -119,7 +119,7 @@ public class ReportingController {
 	}
 
 	@RequestMapping(value = "/all/reports/batch/{batchId}/overall/trainee/{traineeId}/bar-batch-overall-trainee", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public ResponseEntity<Map<String, Double[]>> getBatchOverallTraineeBarChart(@PathVariable Integer batchId,
 			@PathVariable Integer traineeId) {
 		log.info(
@@ -128,14 +128,14 @@ public class ReportingController {
 	}
 
 	@RequestMapping(value = "/all/reports/batch/{batchId}/overall/bar-batch-overall", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public ResponseEntity<Map<String, Double>> getBatchOverallBarChart(@PathVariable Integer batchId) {
 		log.info("getBatchOverallBarChart   ===>   /all/reports/batch/{batchId}/overall/bar-batch-overall");
 		return new ResponseEntity<>(reportingService.getBatchOverallBarChart(batchId), HttpStatus.OK);
 	}
 
 	@RequestMapping(value = "/all/reports/batch/{batchId}/week/{weekId}/trainee/{traineeId}/bar-batch-week-trainee", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public ResponseEntity<Map<String, Double[]>> getBatchWeekTraineeBarChart(@PathVariable Integer batchId,
 			@PathVariable Integer weekId, @PathVariable Integer traineeId) {
 		log.info(
@@ -150,7 +150,7 @@ public class ReportingController {
 	 *******************************************************
 	 */
 	@RequestMapping(value = "/all/reports/batch/{batchId}/week/{week}/trainee/{traineeId}/line-trainee-up-to-week", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public ResponseEntity<Map<Integer, Double[]>> getTraineeUpToWeekLineChart(@PathVariable int batchId,
 			@PathVariable int week, @PathVariable int traineeId) {
 		log.info(
@@ -160,7 +160,7 @@ public class ReportingController {
 	}
 
 	@RequestMapping(value = "/all/reports/batch/{batchId}/overall/trainee/{traineeId}/line-trainee-overall", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public ResponseEntity<Map<Integer, Double[]>> getTraineeOverallLineChart(@PathVariable Integer batchId,
 			@PathVariable Integer traineeId) {
 		log.info(
@@ -169,14 +169,14 @@ public class ReportingController {
 	}
 
 	@RequestMapping(value = "/all/reports/batch/{batchId}/overall/line-batch-overall", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public ResponseEntity<Map<Integer, Double>> getBatchOverallLineChart(@PathVariable int batchId) {
 		log.info("getBatchOverallLineChart   ===>   /all/reports/batch/{batchId}/overall/line-batch-overall");
 		return new ResponseEntity<>(reportingService.getBatchOverallLineChart(batchId), HttpStatus.OK);
 	}
 
 	@RequestMapping(value = "/all/reports/dashboard", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	@PreAuthorize("hasAnyRole('VP', 'QC')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'STAGING')")
 	public ResponseEntity<Map<String, Map<Integer, Double>>> getCurrentBatchesLineChart() {
 		log.info("getCurrentBatchesLineChart   ===>  /all/reports/dashboard");
 		return new ResponseEntity<>(reportingService.getAllCurrentBatchesLineChart(), HttpStatus.OK);
@@ -189,7 +189,7 @@ public class ReportingController {
 	 */
 
 	@RequestMapping(value = "/all/reports/week/{week}/trainee/{traineeId}/radar-trainee-up-to-week", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public ResponseEntity<Map<String, Double>> getTraineeUpToWeekRadarChart(@PathVariable Integer traineeId,
 			@PathVariable Integer week) {
 		log.info(
@@ -198,21 +198,21 @@ public class ReportingController {
 	}
 
 	@RequestMapping(value = "/all/reports/trainee/{traineeId}/radar-trainee-overall", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public ResponseEntity<Map<String, Double>> getTraineeOverallRadarChart(@PathVariable Integer traineeId) {
 		log.info("getTraineeOverallRadarChart   ===>   /all/reports/trainee/{traineeId}/radar-trainee-overall");
 		return new ResponseEntity<>(reportingService.getTraineeOverallRadarChart(traineeId), HttpStatus.OK);
 	}
 
 	@RequestMapping(value = "/all/reports/batch/{batchId}/overall/radar-batch-overall", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public ResponseEntity<Map<String, Double>> getBatchOverallRadarChart(@PathVariable Integer batchId) {
 		log.info("getBatchOverallRadarChart   ===>   /all/reports/batch/{batchId}/overall/radar-batch-overall");
 		return new ResponseEntity<>(reportingService.getBatchOverallRadarChart(batchId), HttpStatus.OK);
 	}
 
 	@RequestMapping(value = "/all/reports/batch/{batchId}/radar-batch-all-trainees", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public ResponseEntity<Map<String, Map<String, Double>>> getBatchAllTraineesRadarChart(
 			@PathVariable Integer batchId) {
 		log.info("getBatchOverallRadarChart   ===>   /all/reports/batch/{batchId}/overall/radar-batch-overall");
@@ -225,14 +225,14 @@ public class ReportingController {
 	 *******************************************************
 	 */
 	@RequestMapping(value = "/all/assessments/average/{batchId}/{week}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public ResponseEntity<Double> getBatchWeekAverageValue(@PathVariable Integer batchId, @PathVariable Integer week) {
 		log.info("getBatchWeekAverageValue   ===>   /all/reports/batch/{batchId}/overall/line-batch-overall");
 		return new ResponseEntity<>(reportingService.getAvgBatchWeekValue(batchId, week), HttpStatus.OK);
 	}
 
 	@RequestMapping(value = "/all/assessments/categories/batch/{batchId}/week/{week}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public ResponseEntity<Set<String>> getTechnologiesForTheWeek(@PathVariable Integer batchId,
 			@PathVariable Integer week) {
 		log.info("getBatchWeekAverageValue   ===>   /all/reports/batch/{batchId}/overall/line-batch-overall");

--- a/caliber/src/main/java/com/revature/caliber/controllers/SalesforceController.java
+++ b/caliber/src/main/java/com/revature/caliber/controllers/SalesforceController.java
@@ -1,6 +1,5 @@
 package com.revature.caliber.controllers;
 
-
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
@@ -20,55 +19,58 @@ import com.revature.caliber.services.SalesforceService;
 public class SalesforceController {
 
 	private static final Logger log = Logger.getLogger(SalesforceController.class);
-	
+
 	@Autowired
 	private SalesforceService salesforceService;
 
 	public void setSalesforceService(SalesforceService salesforceService) {
 		this.salesforceService = salesforceService;
 	}
-	
+
 	/**
-	 * Delete when we're done with development
-	 * Used to grab access_token for running local tests of Salesforce API
+	 * Delete when we're done with development Used to grab access_token for running
+	 * local tests of Salesforce API
+	 * 
 	 * @return
 	 */
-	//@RequestMapping(value="/salesforce/token", method=RequestMethod.GET)
-	public String getSalesforceToken(){
+	// @RequestMapping(value="/salesforce/token", method=RequestMethod.GET)
+	public String getSalesforceToken() {
 		log.info("Getting access_token for testing purposes only!");
 		return ((SalesforceUser) SecurityContextHolder.getContext().getAuthentication().getPrincipal())
 				.getSalesforceToken().getAccessToken();
 	}
-	
+
 	/**
 	 * Gets all the relevent batches
+	 * 
 	 * @return Batches in JSON
 	 */
-	@RequestMapping(value="/all/batch/import", method=RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	@RequestMapping(value = "/all/batch/import", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
-	public Iterable<Batch> getAllReleventBatches(){
+	public Iterable<Batch> getAllReleventBatches() {
 		return salesforceService.getAllRelevantBatches();
 	}
 
 	/**
 	 * Gets all trainees for a given batch
+	 * 
 	 * @return Batches in JSON
 	 */
-	@RequestMapping(value="/all/trainee/import", method=RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	@RequestMapping(value = "/all/trainee/import", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
-	public Iterable<Trainee> getAllTraineesFromBatch(@RequestParam String resourceId){
+	public Iterable<Trainee> getAllTraineesFromBatch(@RequestParam String resourceId) {
 		return salesforceService.getAllTraineesFromBatch(resourceId);
 	}
-	
+
 	/**
-	 * Gets all the relevant batches or response String. 
-	 * Testing purpose only. 
+	 * Gets all the relevant batches or response String. Testing purpose only.
+	 * 
 	 * @return Batches in JSON
 	 */
-	@RequestMapping(value="/all/batch/import/log", method=RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	@RequestMapping(value = "/all/batch/import/log", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
-	public String logBatches(){
+	public String logBatches() {
 		return salesforceService.logBatches();
 	}
-	
+
 }

--- a/caliber/src/main/java/com/revature/caliber/controllers/SalesforceController.java
+++ b/caliber/src/main/java/com/revature/caliber/controllers/SalesforceController.java
@@ -4,6 +4,7 @@ package com.revature.caliber.controllers;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -44,6 +45,7 @@ public class SalesforceController {
 	 * @return Batches in JSON
 	 */
 	@RequestMapping(value="/all/batch/import", method=RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	@PreAuthorize("hasAnyRole('VP', 'QC')")
 	public Iterable<Batch> getAllReleventBatches(){
 		return salesforceService.getAllRelevantBatches();
 	}
@@ -53,6 +55,7 @@ public class SalesforceController {
 	 * @return Batches in JSON
 	 */
 	@RequestMapping(value="/all/trainee/import", method=RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public Iterable<Trainee> getAllTraineesFromBatch(@RequestParam String resourceId){
 		return salesforceService.getAllTraineesFromBatch(resourceId);
 	}
@@ -63,6 +66,7 @@ public class SalesforceController {
 	 * @return Batches in JSON
 	 */
 	@RequestMapping(value="/all/batch/import/log", method=RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	@PreAuthorize("hasAnyRole('VP', 'QC')")
 	public String logBatches(){
 		return salesforceService.logBatches();
 	}

--- a/caliber/src/main/java/com/revature/caliber/controllers/SalesforceController.java
+++ b/caliber/src/main/java/com/revature/caliber/controllers/SalesforceController.java
@@ -45,7 +45,7 @@ public class SalesforceController {
 	 * @return Batches in JSON
 	 */
 	@RequestMapping(value="/all/batch/import", method=RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	@PreAuthorize("hasAnyRole('VP', 'QC')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public Iterable<Batch> getAllReleventBatches(){
 		return salesforceService.getAllRelevantBatches();
 	}
@@ -66,7 +66,7 @@ public class SalesforceController {
 	 * @return Batches in JSON
 	 */
 	@RequestMapping(value="/all/batch/import/log", method=RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	@PreAuthorize("hasAnyRole('VP', 'QC')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public String logBatches(){
 		return salesforceService.logBatches();
 	}

--- a/caliber/src/main/java/com/revature/caliber/controllers/SalesforceController.java
+++ b/caliber/src/main/java/com/revature/caliber/controllers/SalesforceController.java
@@ -45,7 +45,7 @@ public class SalesforceController {
 	 * @return Batches in JSON
 	 */
 	@RequestMapping(value="/all/batch/import", method=RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public Iterable<Batch> getAllReleventBatches(){
 		return salesforceService.getAllRelevantBatches();
 	}
@@ -55,7 +55,7 @@ public class SalesforceController {
 	 * @return Batches in JSON
 	 */
 	@RequestMapping(value="/all/trainee/import", method=RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public Iterable<Trainee> getAllTraineesFromBatch(@RequestParam String resourceId){
 		return salesforceService.getAllTraineesFromBatch(resourceId);
 	}
@@ -66,7 +66,7 @@ public class SalesforceController {
 	 * @return Batches in JSON
 	 */
 	@RequestMapping(value="/all/batch/import/log", method=RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public String logBatches(){
 		return salesforceService.logBatches();
 	}

--- a/caliber/src/main/java/com/revature/caliber/controllers/TrainingController.java
+++ b/caliber/src/main/java/com/revature/caliber/controllers/TrainingController.java
@@ -123,7 +123,7 @@ public class TrainingController {
 	 */
 	@RequestMapping(value = "/vp/trainer/titles", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
-	@PreAuthorize("hasRole('VP', 'STAGING')")
+	@PreAuthorize("hasAnyRole('VP', 'TRAINER', 'STAGING')")
 	public ResponseEntity<List<String>> getAllTrainersTitles() {
 		log.info("Fetching all trainers titles");
 		List<String> trainers = trainingService.findAllTrainerTitles();
@@ -137,7 +137,7 @@ public class TrainingController {
 	 */
 	@RequestMapping(value = "/all/trainer/all", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
-	@PreAuthorize("hasRole('VP', 'STAGING')")
+	@PreAuthorize("hasAnyRole('VP', 'TRAINER', 'STAGING')")
 	public ResponseEntity<List<Trainer>> getAllTrainers() {
 		log.info("Fetching all trainers");
 		List<Trainer> trainers = trainingService.findAllTrainers();
@@ -176,7 +176,7 @@ public class TrainingController {
 	 */
 	@RequestMapping(value = "/all/batch/create", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
-	@PreAuthorize("hasRole('VP', 'TRAINER')")
+	@PreAuthorize("hasAnyRole('VP', 'TRAINER')")
 	public ResponseEntity<Batch> createBatch(@Valid @RequestBody Batch batch) {
 		log.info("Saving batch: " + batch);
 		trainingService.save(batch);
@@ -208,7 +208,7 @@ public class TrainingController {
 	 */
 	@RequestMapping(value = "/all/batch/delete/{id}", method = RequestMethod.DELETE, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
-	@PreAuthorize("hasRole('VP', 'TRAINER')")
+	@PreAuthorize("hasAnyRole('VP', 'TRAINER')")
 	public ResponseEntity<Void> deleteBatch(@PathVariable int id) {
 		Batch batch = new Batch();
 		batch.setBatchId(id);
@@ -266,7 +266,7 @@ public class TrainingController {
 	
 	@RequestMapping(value = "/all/locations", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
-	@PreAuthorize("hasRole('VP', 'STAGING')")
+	@PreAuthorize("hasAnyRole('VP', 'STAGING')")
 	public ResponseEntity<List<String>> findCommonLocations() {
 		log.info("Fetching common training locations");
 		return new ResponseEntity<>(trainingService.findCommonLocations(), HttpStatus.OK);
@@ -305,7 +305,7 @@ public class TrainingController {
 	 */
 	@RequestMapping(value = "/all/trainee/create", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
-	@PreAuthorize("hasRole('VP', 'TRAINER')")
+	@PreAuthorize("hasAnyRole('VP', 'TRAINER')")
 	public ResponseEntity<Trainee> createTrainee(@Valid @RequestBody Trainee trainee) {
 		log.info("Saving trainee: " + trainee);
 		trainingService.save(trainee);

--- a/caliber/src/main/java/com/revature/caliber/controllers/TrainingController.java
+++ b/caliber/src/main/java/com/revature/caliber/controllers/TrainingController.java
@@ -159,7 +159,7 @@ public class TrainingController {
 	 */
 	@RequestMapping(value = "/trainer/batch/all", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
-	@PreAuthorize("hasRole('VP')")
+	@PreAuthorize("hasAnyRole('VP', 'TRAINER')")
 	public ResponseEntity<List<Batch>> findAllBatchesByTrainer(Authentication auth) {
 		Trainer userPrincipal = getPrincipal(auth);
 		log.info("Getting all batches for trainer: " + userPrincipal);
@@ -176,7 +176,7 @@ public class TrainingController {
 	 */
 	@RequestMapping(value = "/all/batch/create", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
-	@PreAuthorize("hasRole('VP')")
+	@PreAuthorize("hasRole('VP', 'TRAINER')")
 	public ResponseEntity<Batch> createBatch(@Valid @RequestBody Batch batch) {
 		log.info("Saving batch: " + batch);
 		trainingService.save(batch);
@@ -192,7 +192,7 @@ public class TrainingController {
 	 */
 	@RequestMapping(value = "/all/batch/update", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
-	@PreAuthorize("hasRole('VP')")
+	@PreAuthorize("hasAnyRole('VP', 'TRAINER')")
 	public ResponseEntity<Void> updateBatch(@Valid @RequestBody Batch batch) {
 		log.info("Updating batch: " + batch);
 		trainingService.update(batch);
@@ -208,7 +208,7 @@ public class TrainingController {
 	 */
 	@RequestMapping(value = "/all/batch/delete/{id}", method = RequestMethod.DELETE, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
-	@PreAuthorize("hasRole('VP')")
+	@PreAuthorize("hasRole('VP', 'TRAINER')")
 	public ResponseEntity<Void> deleteBatch(@PathVariable int id) {
 		Batch batch = new Batch();
 		batch.setBatchId(id);
@@ -225,7 +225,7 @@ public class TrainingController {
 	@RequestMapping(value = {
 			"/vp/batch/all/current" }, method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
-	@PreAuthorize("hasRole('VP')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public ResponseEntity<List<Batch>> getAllCurrentBatches() {
 		log.info("Fetching all current batches");
 		List<Batch> batches = trainingService.findAllCurrentBatches();
@@ -305,7 +305,7 @@ public class TrainingController {
 	 */
 	@RequestMapping(value = "/all/trainee/create", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
-	@PreAuthorize("hasRole('VP')")
+	@PreAuthorize("hasRole('VP', 'TRAINER')")
 	public ResponseEntity<Trainee> createTrainee(@Valid @RequestBody Trainee trainee) {
 		log.info("Saving trainee: " + trainee);
 		trainingService.save(trainee);
@@ -321,7 +321,7 @@ public class TrainingController {
 	 */
 	@RequestMapping(value = "/all/trainee/update", method = RequestMethod.PUT, consumes = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
-	@PreAuthorize("hasRole('VP')")
+	@PreAuthorize("hasAnyRole('VP', 'TRAINER')")
 	public ResponseEntity<Void> updateTrainee(@Valid @RequestBody Trainee trainee) {
 		log.info("Updating trainee: " + trainee);
 		trainingService.update(trainee);

--- a/caliber/src/main/java/com/revature/caliber/controllers/TrainingController.java
+++ b/caliber/src/main/java/com/revature/caliber/controllers/TrainingController.java
@@ -123,7 +123,7 @@ public class TrainingController {
 	 */
 	@RequestMapping(value = "/vp/trainer/titles", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
-	@PreAuthorize("hasRole('VP')")
+	@PreAuthorize("hasRole('VP', 'STAGING')")
 	public ResponseEntity<List<String>> getAllTrainersTitles() {
 		log.info("Fetching all trainers titles");
 		List<String> trainers = trainingService.findAllTrainerTitles();
@@ -137,7 +137,7 @@ public class TrainingController {
 	 */
 	@RequestMapping(value = "/all/trainer/all", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
-	@PreAuthorize("hasRole('VP')")
+	@PreAuthorize("hasRole('VP', 'STAGING')")
 	public ResponseEntity<List<Trainer>> getAllTrainers() {
 		log.info("Fetching all trainers");
 		List<Trainer> trainers = trainingService.findAllTrainers();
@@ -159,7 +159,7 @@ public class TrainingController {
 	 */
 	@RequestMapping(value = "/trainer/batch/all", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
-	@PreAuthorize("hasAnyRole('VP', 'TRAINER')")
+	@PreAuthorize("hasAnyRole('VP', 'TRAINER', 'STAGING')")
 	public ResponseEntity<List<Batch>> findAllBatchesByTrainer(Authentication auth) {
 		Trainer userPrincipal = getPrincipal(auth);
 		log.info("Getting all batches for trainer: " + userPrincipal);
@@ -225,7 +225,7 @@ public class TrainingController {
 	@RequestMapping(value = {
 			"/vp/batch/all/current" }, method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
-	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public ResponseEntity<List<Batch>> getAllCurrentBatches() {
 		log.info("Fetching all current batches");
 		List<Batch> batches = trainingService.findAllCurrentBatches();
@@ -240,7 +240,7 @@ public class TrainingController {
 	@RequestMapping(value = { "/qc/batch/all",
 			"/vp/batch/all" }, method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
-	@PreAuthorize("hasAnyRole('VP', 'QC')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'STAGING')")
 	public ResponseEntity<List<Batch>> getAllBatches() {
 		log.info("Fetching all batches");
 		List<Batch> batches = trainingService.findAllBatches();
@@ -266,7 +266,7 @@ public class TrainingController {
 	
 	@RequestMapping(value = "/all/locations", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
-	@PreAuthorize("hasRole('VP')")
+	@PreAuthorize("hasRole('VP', 'STAGING')")
 	public ResponseEntity<List<String>> findCommonLocations() {
 		log.info("Fetching common training locations");
 		return new ResponseEntity<>(trainingService.findCommonLocations(), HttpStatus.OK);
@@ -280,7 +280,7 @@ public class TrainingController {
 	 */
 	@RequestMapping(value = "/all/trainee", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
-	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public ResponseEntity<List<Trainee>> findAllByBatch(@RequestParam(required = true) Integer batch) {
 		log.info("Finding trainees for batch: " + batch);
 		List<Trainee> trainees = trainingService.findAllTraineesByBatch(batch);
@@ -289,7 +289,7 @@ public class TrainingController {
 
 	@RequestMapping(value = "/all/trainee/dropped", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
-	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER', 'STAGING')")
 	public ResponseEntity<List<Trainee>> findAllDroppedByBatch(@RequestParam(required = true) Integer batch) {
 		log.info("Finding dropped trainees for batch: " + batch);
 		List<Trainee> trainees = trainingService.findAllDroppedTraineesByBatch(batch);

--- a/caliber/src/main/java/com/revature/caliber/controllers/TrainingController.java
+++ b/caliber/src/main/java/com/revature/caliber/controllers/TrainingController.java
@@ -46,7 +46,7 @@ public class TrainingController {
 	public void setTrainingService(TrainingService trainingService) {
 		this.trainingService = trainingService;
 	}
-	
+
 	/*
 	 *******************************************************
 	 * TODO TRAINER SERVICES
@@ -95,7 +95,7 @@ public class TrainingController {
 	 */
 	@RequestMapping(value = "/training/trainer/byemail/{email}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
-//	@PreAuthorize("hasRole('VP')")
+	// @PreAuthorize("hasRole('VP')")
 	@PreAuthorize("permitAll")
 	public ResponseEntity<Trainer> findTrainer(@PathVariable String email) {
 		log.info("Find trainer by email " + email);
@@ -251,8 +251,7 @@ public class TrainingController {
 	}
 
 	/**
-	 * Adds a new week to the batch. Increments counter of total_weeks in
-	 * database
+	 * Adds a new week to the batch. Increments counter of total_weeks in database
 	 * 
 	 * @param batchId
 	 * @return
@@ -265,7 +264,7 @@ public class TrainingController {
 		trainingService.addWeek(batchId);
 		return new ResponseEntity<>(HttpStatus.CREATED);
 	}
-	
+
 	@RequestMapping(value = "/all/locations", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
 	@PreAuthorize("hasAnyRole('VP', 'STAGING')")

--- a/caliber/src/main/java/com/revature/caliber/controllers/TrainingController.java
+++ b/caliber/src/main/java/com/revature/caliber/controllers/TrainingController.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
@@ -61,6 +62,7 @@ public class TrainingController {
 	 */
 	@RequestMapping(value = "/vp/trainer/create", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
+	@PreAuthorize("hasRole('VP')")
 	public ResponseEntity<Trainer> createTrainer(@Valid @RequestBody Trainer trainer) {
 		log.info("Saving trainer: " + trainer);
 		trainingService.createTrainer(trainer);
@@ -76,6 +78,7 @@ public class TrainingController {
 	 */
 	@RequestMapping(value = "/vp/trainer/update", method = RequestMethod.PUT, consumes = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
+	@PreAuthorize("hasRole('VP')")
 	public ResponseEntity<Void> updateTrainer(@Valid @RequestBody Trainer trainer) {
 		log.info("Updating trainer: " + trainer);
 		trainingService.update(trainer);
@@ -91,6 +94,7 @@ public class TrainingController {
 	 */
 	@RequestMapping(value = "/training/trainer/byemail/{email}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
+//	@PreAuthorize("hasRole('VP')")
 	public ResponseEntity<Trainer> findTrainer(@PathVariable String email) {
 		log.info("Find trainer by email " + email);
 		Trainer trainer = trainingService.findTrainer(email);
@@ -105,6 +109,7 @@ public class TrainingController {
 	 */
 	@RequestMapping(value = "/vp/trainer/delete", method = RequestMethod.DELETE, consumes = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
+	@PreAuthorize("hasRole('VP')")
 	public ResponseEntity<Void> makeInactive(@Valid @RequestBody Trainer trainer) {
 		log.info("Updating trainer: " + trainer);
 		trainingService.makeInactive(trainer);
@@ -118,6 +123,7 @@ public class TrainingController {
 	 */
 	@RequestMapping(value = "/vp/trainer/titles", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
+	@PreAuthorize("hasRole('VP')")
 	public ResponseEntity<List<String>> getAllTrainersTitles() {
 		log.info("Fetching all trainers titles");
 		List<String> trainers = trainingService.findAllTrainerTitles();
@@ -131,6 +137,7 @@ public class TrainingController {
 	 */
 	@RequestMapping(value = "/all/trainer/all", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
+	@PreAuthorize("hasRole('VP')")
 	public ResponseEntity<List<Trainer>> getAllTrainers() {
 		log.info("Fetching all trainers");
 		List<Trainer> trainers = trainingService.findAllTrainers();
@@ -152,6 +159,7 @@ public class TrainingController {
 	 */
 	@RequestMapping(value = "/trainer/batch/all", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
+	@PreAuthorize("hasRole('VP')")
 	public ResponseEntity<List<Batch>> findAllBatchesByTrainer(Authentication auth) {
 		Trainer userPrincipal = getPrincipal(auth);
 		log.info("Getting all batches for trainer: " + userPrincipal);
@@ -168,6 +176,7 @@ public class TrainingController {
 	 */
 	@RequestMapping(value = "/all/batch/create", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
+	@PreAuthorize("hasRole('VP')")
 	public ResponseEntity<Batch> createBatch(@Valid @RequestBody Batch batch) {
 		log.info("Saving batch: " + batch);
 		trainingService.save(batch);
@@ -183,6 +192,7 @@ public class TrainingController {
 	 */
 	@RequestMapping(value = "/all/batch/update", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
+	@PreAuthorize("hasRole('VP')")
 	public ResponseEntity<Void> updateBatch(@Valid @RequestBody Batch batch) {
 		log.info("Updating batch: " + batch);
 		trainingService.update(batch);
@@ -198,6 +208,7 @@ public class TrainingController {
 	 */
 	@RequestMapping(value = "/all/batch/delete/{id}", method = RequestMethod.DELETE, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
+	@PreAuthorize("hasRole('VP')")
 	public ResponseEntity<Void> deleteBatch(@PathVariable int id) {
 		Batch batch = new Batch();
 		batch.setBatchId(id);
@@ -214,6 +225,7 @@ public class TrainingController {
 	@RequestMapping(value = {
 			"/vp/batch/all/current" }, method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
+	@PreAuthorize("hasRole('VP')")
 	public ResponseEntity<List<Batch>> getAllCurrentBatches() {
 		log.info("Fetching all current batches");
 		List<Batch> batches = trainingService.findAllCurrentBatches();
@@ -228,6 +240,7 @@ public class TrainingController {
 	@RequestMapping(value = { "/qc/batch/all",
 			"/vp/batch/all" }, method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
+	@PreAuthorize("hasAnyRole('VP', 'QC')")
 	public ResponseEntity<List<Batch>> getAllBatches() {
 		log.info("Fetching all batches");
 		List<Batch> batches = trainingService.findAllBatches();
@@ -244,6 +257,7 @@ public class TrainingController {
 	 */
 	@RequestMapping(value = "/trainer/week/new/{batchId}", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
+	@PreAuthorize("hasAnyRole('VP', 'TRAINER')")
 	public ResponseEntity<Void> createWeek(@PathVariable int batchId) {
 		log.info("Adding week to batch: " + batchId);
 		trainingService.addWeek(batchId);
@@ -252,6 +266,7 @@ public class TrainingController {
 	
 	@RequestMapping(value = "/all/locations", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
+	@PreAuthorize("hasRole('VP')")
 	public ResponseEntity<List<String>> findCommonLocations() {
 		log.info("Fetching common training locations");
 		return new ResponseEntity<>(trainingService.findCommonLocations(), HttpStatus.OK);
@@ -265,6 +280,7 @@ public class TrainingController {
 	 */
 	@RequestMapping(value = "/all/trainee", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public ResponseEntity<List<Trainee>> findAllByBatch(@RequestParam(required = true) Integer batch) {
 		log.info("Finding trainees for batch: " + batch);
 		List<Trainee> trainees = trainingService.findAllTraineesByBatch(batch);
@@ -273,6 +289,7 @@ public class TrainingController {
 
 	@RequestMapping(value = "/all/trainee/dropped", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
+	@PreAuthorize("hasAnyRole('VP', 'QC', 'TRAINER')")
 	public ResponseEntity<List<Trainee>> findAllDroppedByBatch(@RequestParam(required = true) Integer batch) {
 		log.info("Finding dropped trainees for batch: " + batch);
 		List<Trainee> trainees = trainingService.findAllDroppedTraineesByBatch(batch);
@@ -288,6 +305,7 @@ public class TrainingController {
 	 */
 	@RequestMapping(value = "/all/trainee/create", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
+	@PreAuthorize("hasRole('VP')")
 	public ResponseEntity<Trainee> createTrainee(@Valid @RequestBody Trainee trainee) {
 		log.info("Saving trainee: " + trainee);
 		trainingService.save(trainee);
@@ -303,6 +321,7 @@ public class TrainingController {
 	 */
 	@RequestMapping(value = "/all/trainee/update", method = RequestMethod.PUT, consumes = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
+	@PreAuthorize("hasRole('VP')")
 	public ResponseEntity<Void> updateTrainee(@Valid @RequestBody Trainee trainee) {
 		log.info("Updating trainee: " + trainee);
 		trainingService.update(trainee);
@@ -318,6 +337,7 @@ public class TrainingController {
 	 */
 	@RequestMapping(value = "/all/trainee/delete/{id}", method = RequestMethod.DELETE)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
+	@PreAuthorize("hasRole('VP')")
 	public ResponseEntity<Void> deleteTrainee(@PathVariable int id) {
 		Trainee trainee = new Trainee();
 		trainee.setTraineeId(id);
@@ -328,6 +348,7 @@ public class TrainingController {
 
 	@RequestMapping(value = "/all/trainee/getByEmail/{traineeEmail}", method = RequestMethod.GET)
 	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRED)
+	@PreAuthorize("hasRole('VP')")
 	public ResponseEntity<Trainee> retreiveTraineeByEmail(@PathVariable String traineeEmail) {
 		Trainee trainee = trainingService.findTraineeByEmail(traineeEmail);
 		return new ResponseEntity<>(trainee, HttpStatus.OK);

--- a/caliber/src/main/java/com/revature/caliber/controllers/TypeController.java
+++ b/caliber/src/main/java/com/revature/caliber/controllers/TypeController.java
@@ -48,7 +48,7 @@ public class TypeController {
 	 * @return the response entity
 	 */
 	@RequestMapping(value = "/skill/all", method = RequestMethod.GET)
-	 @PreAuthorize("hasAnyRole('VP', 'STAGING')")
+	@PreAuthorize("hasAnyRole('VP', 'STAGING')")
 	public ResponseEntity<List<String>> allSkillTypes() {
 		log.info("Fetching skill types");
 		List<String> types = Stream.of(SkillType.values()).map(Enum::toString).collect(Collectors.toList());
@@ -61,7 +61,7 @@ public class TypeController {
 	 * @return the response entity
 	 */
 	@RequestMapping(value = "/training/all", method = RequestMethod.GET)
-	 @PreAuthorize("hasAnyRole('VP', 'STAGING')")
+	@PreAuthorize("hasAnyRole('VP', 'STAGING')")
 	public ResponseEntity<List<String>> allTrainingTypes() {
 		log.info("Fetching training types");
 		List<String> types = Stream.of(TrainingType.values()).map(Enum::name).collect(Collectors.toList());
@@ -74,7 +74,7 @@ public class TypeController {
 	 * @return the response entity
 	 */
 	@RequestMapping(value = "/trainingstatus/all", method = RequestMethod.GET)
-	 @PreAuthorize("hasAnyRole('VP', 'STAGING')")
+	@PreAuthorize("hasAnyRole('VP', 'STAGING')")
 	public ResponseEntity<List<String>> allTrainingStatusTypes() {
 		log.info("Fetching training status types");
 		List<String> types = Stream.of(TrainingStatus.values()).map(Enum::name).collect(Collectors.toList());
@@ -87,7 +87,7 @@ public class TypeController {
 	 * @return the response entity
 	 */
 	@RequestMapping(value = "/note/all", method = RequestMethod.GET)
-	 @PreAuthorize("hasAnyRole('VP', 'STAGING')")
+	@PreAuthorize("hasAnyRole('VP', 'STAGING')")
 	public ResponseEntity<List<String>> allNoteTypes() {
 		log.info("Fetching note types");
 		List<String> types = Stream.of(NoteType.values()).map(Enum::name).collect(Collectors.toList());
@@ -100,7 +100,7 @@ public class TypeController {
 	 * @return the response entity
 	 */
 	@RequestMapping(value = "/qcstatus/all", method = RequestMethod.GET)
-	 @PreAuthorize("hasAnyRole('VP', 'STAGING')")
+	@PreAuthorize("hasAnyRole('VP', 'STAGING')")
 	public ResponseEntity<List<String>> allQCStatusTypes() {
 		log.info("Fetching QC status types");
 		List<String> types = Stream.of(QCStatus.values()).map(Enum::name).collect(Collectors.toList());
@@ -115,13 +115,13 @@ public class TypeController {
 	 * @return the response entity
 	 */
 	@RequestMapping(value = "/assessment/all", method = RequestMethod.GET)
-	 @PreAuthorize("hasAnyRole('VP', 'STAGING')")
+	@PreAuthorize("hasAnyRole('VP', 'STAGING')")
 	public ResponseEntity<List<String>> allAssessmentTypes() {
 		log.info("Fetching assessment types");
 		List<String> types = Stream.of(AssessmentType.values()).map(Enum::name).collect(Collectors.toList());
 		return new ResponseEntity<>(types, HttpStatus.OK);
 	}
-	
+
 	/**
 	 * Get Trainer Tier for dropdown selection on the UI
 	 *
@@ -130,10 +130,17 @@ public class TypeController {
 	 * @return the response entity
 	 */
 	@RequestMapping(value = "/trainer/role/all", method = RequestMethod.GET)
-	 @PreAuthorize("hasAnyRole('VP', 'STAGING')")
+	@PreAuthorize("hasAnyRole('VP', 'STAGING')")
 	public ResponseEntity<List<String>> allTrainerRoles() {
 		log.info("Fetching Trainer Roles");
-		List<String> types = Stream.of(TrainerRole.values()).map(Enum::name).collect(Collectors.toList());     //Used toString to Display the roles without the underscore
+		List<String> types = Stream.of(TrainerRole.values()).map(Enum::name).collect(Collectors.toList()); // Used
+																											// toString
+																											// to
+																											// Display
+																											// the roles
+																											// without
+																											// the
+																											// underscore
 		return new ResponseEntity<>(types, HttpStatus.OK);
 	}
 }

--- a/caliber/src/main/java/com/revature/caliber/controllers/TypeController.java
+++ b/caliber/src/main/java/com/revature/caliber/controllers/TypeController.java
@@ -8,6 +8,7 @@ import org.apache.log4j.Logger;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
@@ -46,7 +47,7 @@ public class TypeController {
 	 * @return the response entity
 	 */
 	@RequestMapping(value = "/skill/all", method = RequestMethod.GET)
-	// @PreAuthorize("hasAnyRole('TRAINER, QC, VP')")
+	 @PreAuthorize("hasRole('VP')")
 	public ResponseEntity<List<String>> allSkillTypes() {
 		log.info("Fetching skill types");
 		List<String> types = Stream.of(SkillType.values()).map(Enum::toString).collect(Collectors.toList());
@@ -59,7 +60,7 @@ public class TypeController {
 	 * @return the response entity
 	 */
 	@RequestMapping(value = "/training/all", method = RequestMethod.GET)
-	// @PreAuthorize("hasAnyRole('TRAINER, QC, VP')")
+	 @PreAuthorize("hasRole('VP')")
 	public ResponseEntity<List<String>> allTrainingTypes() {
 		log.info("Fetching training types");
 		List<String> types = Stream.of(TrainingType.values()).map(Enum::name).collect(Collectors.toList());
@@ -72,7 +73,7 @@ public class TypeController {
 	 * @return the response entity
 	 */
 	@RequestMapping(value = "/trainingstatus/all", method = RequestMethod.GET)
-	// @PreAuthorize("hasAnyRole('TRAINER, QC, VP')")
+	 @PreAuthorize("hasRole('VP')")
 	public ResponseEntity<List<String>> allTrainingStatusTypes() {
 		log.info("Fetching training status types");
 		List<String> types = Stream.of(TrainingStatus.values()).map(Enum::name).collect(Collectors.toList());
@@ -85,7 +86,7 @@ public class TypeController {
 	 * @return the response entity
 	 */
 	@RequestMapping(value = "/note/all", method = RequestMethod.GET)
-	// @PreAuthorize("hasAnyRole('TRAINER, QC, VP')")
+	 @PreAuthorize("hasRole('VP')")
 	public ResponseEntity<List<String>> allNoteTypes() {
 		log.info("Fetching note types");
 		List<String> types = Stream.of(NoteType.values()).map(Enum::name).collect(Collectors.toList());
@@ -98,7 +99,7 @@ public class TypeController {
 	 * @return the response entity
 	 */
 	@RequestMapping(value = "/qcstatus/all", method = RequestMethod.GET)
-	// @PreAuthorize("hasAnyRole('TRAINER, QC, VP')")
+	 @PreAuthorize("hasRole('VP')")
 	public ResponseEntity<List<String>> allQCStatusTypes() {
 		log.info("Fetching QC status types");
 		List<String> types = Stream.of(QCStatus.values()).map(Enum::name).collect(Collectors.toList());
@@ -113,7 +114,7 @@ public class TypeController {
 	 * @return the response entity
 	 */
 	@RequestMapping(value = "/assessment/all", method = RequestMethod.GET)
-	// @PreAuthorize("hasAnyRole('TRAINER, QC, VP')")
+	 @PreAuthorize("hasRole('VP')")
 	public ResponseEntity<List<String>> allAssessmentTypes() {
 		log.info("Fetching assessment types");
 		List<String> types = Stream.of(AssessmentType.values()).map(Enum::name).collect(Collectors.toList());
@@ -128,7 +129,7 @@ public class TypeController {
 	 * @return the response entity
 	 */
 	@RequestMapping(value = "/trainer/role/all", method = RequestMethod.GET)
-	// @PreAuthorize("hasAnyRole('TRAINER, QC, VP')")
+	 @PreAuthorize("hasRole('VP')")
 	public ResponseEntity<List<String>> allTrainerRoles() {
 		log.info("Fetching Trainer Roles");
 		List<String> types = Stream.of(TrainerRole.values()).map(Enum::name).collect(Collectors.toList());     //Used toString to Display the roles without the underscore

--- a/caliber/src/main/java/com/revature/caliber/controllers/TypeController.java
+++ b/caliber/src/main/java/com/revature/caliber/controllers/TypeController.java
@@ -47,7 +47,7 @@ public class TypeController {
 	 * @return the response entity
 	 */
 	@RequestMapping(value = "/skill/all", method = RequestMethod.GET)
-	 @PreAuthorize("hasRole('VP')")
+	 @PreAuthorize("hasRole('VP', 'STAGING')")
 	public ResponseEntity<List<String>> allSkillTypes() {
 		log.info("Fetching skill types");
 		List<String> types = Stream.of(SkillType.values()).map(Enum::toString).collect(Collectors.toList());
@@ -60,7 +60,7 @@ public class TypeController {
 	 * @return the response entity
 	 */
 	@RequestMapping(value = "/training/all", method = RequestMethod.GET)
-	 @PreAuthorize("hasRole('VP')")
+	 @PreAuthorize("hasRole('VP', 'STAGING')")
 	public ResponseEntity<List<String>> allTrainingTypes() {
 		log.info("Fetching training types");
 		List<String> types = Stream.of(TrainingType.values()).map(Enum::name).collect(Collectors.toList());
@@ -73,7 +73,7 @@ public class TypeController {
 	 * @return the response entity
 	 */
 	@RequestMapping(value = "/trainingstatus/all", method = RequestMethod.GET)
-	 @PreAuthorize("hasRole('VP')")
+	 @PreAuthorize("hasRole('VP', 'STAGING')")
 	public ResponseEntity<List<String>> allTrainingStatusTypes() {
 		log.info("Fetching training status types");
 		List<String> types = Stream.of(TrainingStatus.values()).map(Enum::name).collect(Collectors.toList());
@@ -86,7 +86,7 @@ public class TypeController {
 	 * @return the response entity
 	 */
 	@RequestMapping(value = "/note/all", method = RequestMethod.GET)
-	 @PreAuthorize("hasRole('VP')")
+	 @PreAuthorize("hasRole('VP', 'STAGING')")
 	public ResponseEntity<List<String>> allNoteTypes() {
 		log.info("Fetching note types");
 		List<String> types = Stream.of(NoteType.values()).map(Enum::name).collect(Collectors.toList());
@@ -99,7 +99,7 @@ public class TypeController {
 	 * @return the response entity
 	 */
 	@RequestMapping(value = "/qcstatus/all", method = RequestMethod.GET)
-	 @PreAuthorize("hasRole('VP')")
+	 @PreAuthorize("hasRole('VP', 'STAGING')")
 	public ResponseEntity<List<String>> allQCStatusTypes() {
 		log.info("Fetching QC status types");
 		List<String> types = Stream.of(QCStatus.values()).map(Enum::name).collect(Collectors.toList());
@@ -114,7 +114,7 @@ public class TypeController {
 	 * @return the response entity
 	 */
 	@RequestMapping(value = "/assessment/all", method = RequestMethod.GET)
-	 @PreAuthorize("hasRole('VP')")
+	 @PreAuthorize("hasRole('VP', 'STAGING')")
 	public ResponseEntity<List<String>> allAssessmentTypes() {
 		log.info("Fetching assessment types");
 		List<String> types = Stream.of(AssessmentType.values()).map(Enum::name).collect(Collectors.toList());
@@ -129,7 +129,7 @@ public class TypeController {
 	 * @return the response entity
 	 */
 	@RequestMapping(value = "/trainer/role/all", method = RequestMethod.GET)
-	 @PreAuthorize("hasRole('VP')")
+	 @PreAuthorize("hasRole('VP', 'STAGING')")
 	public ResponseEntity<List<String>> allTrainerRoles() {
 		log.info("Fetching Trainer Roles");
 		List<String> types = Stream.of(TrainerRole.values()).map(Enum::name).collect(Collectors.toList());     //Used toString to Display the roles without the underscore

--- a/caliber/src/main/java/com/revature/caliber/controllers/TypeController.java
+++ b/caliber/src/main/java/com/revature/caliber/controllers/TypeController.java
@@ -47,7 +47,7 @@ public class TypeController {
 	 * @return the response entity
 	 */
 	@RequestMapping(value = "/skill/all", method = RequestMethod.GET)
-	 @PreAuthorize("hasRole('VP', 'STAGING')")
+	 @PreAuthorize("hasAnyRole('VP', 'STAGING')")
 	public ResponseEntity<List<String>> allSkillTypes() {
 		log.info("Fetching skill types");
 		List<String> types = Stream.of(SkillType.values()).map(Enum::toString).collect(Collectors.toList());
@@ -60,7 +60,7 @@ public class TypeController {
 	 * @return the response entity
 	 */
 	@RequestMapping(value = "/training/all", method = RequestMethod.GET)
-	 @PreAuthorize("hasRole('VP', 'STAGING')")
+	 @PreAuthorize("hasAnyRole('VP', 'STAGING')")
 	public ResponseEntity<List<String>> allTrainingTypes() {
 		log.info("Fetching training types");
 		List<String> types = Stream.of(TrainingType.values()).map(Enum::name).collect(Collectors.toList());
@@ -73,7 +73,7 @@ public class TypeController {
 	 * @return the response entity
 	 */
 	@RequestMapping(value = "/trainingstatus/all", method = RequestMethod.GET)
-	 @PreAuthorize("hasRole('VP', 'STAGING')")
+	 @PreAuthorize("hasAnyRole('VP', 'STAGING')")
 	public ResponseEntity<List<String>> allTrainingStatusTypes() {
 		log.info("Fetching training status types");
 		List<String> types = Stream.of(TrainingStatus.values()).map(Enum::name).collect(Collectors.toList());
@@ -86,7 +86,7 @@ public class TypeController {
 	 * @return the response entity
 	 */
 	@RequestMapping(value = "/note/all", method = RequestMethod.GET)
-	 @PreAuthorize("hasRole('VP', 'STAGING')")
+	 @PreAuthorize("hasAnyRole('VP', 'STAGING')")
 	public ResponseEntity<List<String>> allNoteTypes() {
 		log.info("Fetching note types");
 		List<String> types = Stream.of(NoteType.values()).map(Enum::name).collect(Collectors.toList());
@@ -99,7 +99,7 @@ public class TypeController {
 	 * @return the response entity
 	 */
 	@RequestMapping(value = "/qcstatus/all", method = RequestMethod.GET)
-	 @PreAuthorize("hasRole('VP', 'STAGING')")
+	 @PreAuthorize("hasAnyRole('VP', 'STAGING')")
 	public ResponseEntity<List<String>> allQCStatusTypes() {
 		log.info("Fetching QC status types");
 		List<String> types = Stream.of(QCStatus.values()).map(Enum::name).collect(Collectors.toList());
@@ -114,7 +114,7 @@ public class TypeController {
 	 * @return the response entity
 	 */
 	@RequestMapping(value = "/assessment/all", method = RequestMethod.GET)
-	 @PreAuthorize("hasRole('VP', 'STAGING')")
+	 @PreAuthorize("hasAnyRole('VP', 'STAGING')")
 	public ResponseEntity<List<String>> allAssessmentTypes() {
 		log.info("Fetching assessment types");
 		List<String> types = Stream.of(AssessmentType.values()).map(Enum::name).collect(Collectors.toList());
@@ -129,7 +129,7 @@ public class TypeController {
 	 * @return the response entity
 	 */
 	@RequestMapping(value = "/trainer/role/all", method = RequestMethod.GET)
-	 @PreAuthorize("hasRole('VP', 'STAGING')")
+	 @PreAuthorize("hasAnyRole('VP', 'STAGING')")
 	public ResponseEntity<List<String>> allTrainerRoles() {
 		log.info("Fetching Trainer Roles");
 		List<String> types = Stream.of(TrainerRole.values()).map(Enum::name).collect(Collectors.toList());     //Used toString to Display the roles without the underscore

--- a/caliber/src/main/resources/spring-security.xml
+++ b/caliber/src/main/resources/spring-security.xml
@@ -44,10 +44,11 @@ http://www.springframework.org/schema/security/spring-security.xsd">
   	<security:authentication-manager>
 		<security:authentication-provider>
 			<security:user-service>
-				<security:user authorities="ROLE_VP" name="ROLE_VP" />
+ 				<security:user authorities="ROLE_VP" name="ROLE_VP" />
 				<security:user authorities="ROLE_QC" name="ROLE_QC" />
 				<security:user authorities="ROLE_TRAINER" name="ROLE_TRAINER" />
-			</security:user-service>
+ 				<security:user authorities="ROLE_STAGING" name="ROLE_STAGING" />
+ 			</security:user-service>
 		</security:authentication-provider>
 	</security:authentication-manager>
 </beans>

--- a/caliber/src/main/resources/spring-security.xml
+++ b/caliber/src/main/resources/spring-security.xml
@@ -34,8 +34,9 @@ http://www.springframework.org/schema/security/spring-security.xsd">
 		<security:logout invalidate-session="true"
 			delete-cookies="token, JSESSIONID" />
 	</security:http>
-
-	<security:authentication-manager>
+	
+   	<security:global-method-security pre-post-annotations="enabled"/>
+  	<security:authentication-manager>
 		<security:authentication-provider>
 			<security:user-service>
 				<security:user authorities="ROLE_VP" name="ROLE_VP" />

--- a/caliber/src/main/resources/spring-security.xml
+++ b/caliber/src/main/resources/spring-security.xml
@@ -31,24 +31,24 @@ http://www.springframework.org/schema/security/spring-security.xsd">
 
 		<security:intercept-url pattern="/caliber"
 			access="permitAll" />
-		<security:intercept-url pattern="/home"
-			access="permitAll" />
+		<security:intercept-url pattern="/home" access="permitAll" />
 		<security:intercept-url pattern="/*" access="permitAll" />
-		
+
 		<security:csrf disabled="true" />
 		<security:logout invalidate-session="true"
 			delete-cookies="token, JSESSIONID" />
 	</security:http>
-	
-   	<security:global-method-security pre-post-annotations="enabled"/>
-  	<security:authentication-manager>
+
+	<security:global-method-security
+		pre-post-annotations="enabled" />
+	<security:authentication-manager>
 		<security:authentication-provider>
 			<security:user-service>
- 				<security:user authorities="ROLE_VP" name="ROLE_VP" />
+				<security:user authorities="ROLE_VP" name="ROLE_VP" />
 				<security:user authorities="ROLE_QC" name="ROLE_QC" />
 				<security:user authorities="ROLE_TRAINER" name="ROLE_TRAINER" />
- 				<security:user authorities="ROLE_STAGING" name="ROLE_STAGING" />
- 			</security:user-service>
+				<security:user authorities="ROLE_STAGING" name="ROLE_STAGING" />
+			</security:user-service>
 		</security:authentication-provider>
 	</security:authentication-manager>
 </beans>

--- a/caliber/src/main/webapp/static/app/resources/js/config/routeConfig.js
+++ b/caliber/src/main/webapp/static/app/resources/js/config/routeConfig.js
@@ -90,7 +90,12 @@ angular
 											"trainee-extra-modals@qc.manage" : {
 												templateUrl : "/static/app/partials/manage/trainee-axillary-modals.html"
 											}
+										},
+										//authorize the user
+										onEnter : function(authFactory) {
+											authFactory.authManage();
 										}
+										
 									})
 							.state(
 									"qc.audit",
@@ -104,7 +109,13 @@ angular
 											"confirm-add-weeks-modal@qc.audit" : {
 												templateUrl : "/static/app/partials/assess/confirm-add-weeks-modal.html"
 											}
+										},
+										//authorize the user
+										onEnter : function(authFactory) {
+											authFactory.authAudit();
 										}
+										
+										
 									})
 							.state(
 									"qc.reports",
@@ -131,6 +142,10 @@ angular
 												templateUrl : "/static/app/partials/qc-display.html",
 												controller : "qcAssessController"
 											}
+										},
+										//authorize the user
+										onEnter : function(authFactory) {
+											authFactory.authReports();
 										}
 									})
 							/***************************************************
@@ -169,7 +184,7 @@ angular
 										},
 										// authorize the user
 										onEnter : function(authFactory) {
-											authFactory.authTrainer();
+											authFactory.authImport();
 										}
 									})
 							.state(
@@ -207,6 +222,10 @@ angular
 											"trainee-extra-modals@trainer.manage" : {
 												templateUrl : "/static/app/partials/manage/trainee-axillary-modals.html"
 											}
+										},
+										//authorize the user
+										onEnter : function(authFactory) {
+											authFactory.authManage();
 										}
 									})
 							.state(
@@ -216,6 +235,7 @@ angular
 										views : {
 											"" : {
 												templateUrl : "/static/app/partials/assess/trainer-assess.html",
+												
 												controller : "trainerAssessController"
 											},
 											"trainer-edit-assess@trainer.assess" : {
@@ -225,7 +245,12 @@ angular
 												templateUrl : "/static/app/partials/assess/confirm-add-weeks-modal.html"
 
 											}
+										},
+										//authorize the user
+										onEnter : function(authFactory) {
+											authFactory.authAssess();
 										}
+										
 									})
 							.state(
 									"trainer.reports",
@@ -252,7 +277,12 @@ angular
 												templateUrl : "/static/app/partials/qc-display.html",
 												controller : "qcAssessController"
 											}
+										},
+										//authorize the user
+										onEnter : function(authFactory) {
+											authFactory.authReports();
 										}
+										
 									})
 
 							/***************************************************
@@ -310,7 +340,12 @@ angular
 											"trainer-extra-modals@vp.trainers":{
 												templateUrl : "/static/app/partials/trainers/trainer-auxillary-modals.html"
 											}
-										}
+										},
+										//authorize the users
+										onEnter : function(authFactory) {
+											authFactory.authTrainers();
+										},
+										
 
 									})
 							.state(
@@ -328,7 +363,12 @@ angular
 											"edit-category-form@vp.category" : {
 												templateUrl : "/static/app/partials/category/edit-category-modals.html"
 											}
+										},
+										//authorize the user
+										onEnter : function(authFactory) {
+											authFactory.authCategory();
 										}
+										
 												
 									})
 							.state(
@@ -358,7 +398,12 @@ angular
 											"trainee-extra-modals@vp.manage" : {
 												templateUrl : "/static/app/partials/manage/trainee-axillary-modals.html"
 											}
+										},
+										//authorize the user
+										onEnter : function(authFactory) {
+											authFactory.authManage();
 										}
+										
 									})
 							.state(
 									"vp.assess",
@@ -378,7 +423,12 @@ angular
 												templateUrl : "/static/app/partials/assess/confirm-add-weeks-modal.html"
 
 											}
+										},
+										//authorize the user
+										onEnter : function(authFactory) {
+											authFactory.authAssess();
 										}
+										
 									})
 							.state(
 									"vp.audit",
@@ -398,7 +448,12 @@ angular
 												templateUrl : "/static/app/partials/assess/confirm-add-weeks-modal.html"
 
 											}
+										},
+										//authorize the user
+										onEnter : function(authFactory) {
+											authFactory.authAudit();
 										}
+										
 									})
 							.state(
 									"vp.reports",
@@ -425,7 +480,12 @@ angular
 												templateUrl : "/static/app/partials/qc-display.html",
 												controller : "qcAssessController"
 											}
+										},
+										//authorize the user
+										onEnter : function(authFactory) {
+											authFactory.authReports();
 										}
+										
 									})
 
                             /**
@@ -468,7 +528,11 @@ angular
                                         templateUrl: "/static/app/partials/reports.html",
                                         controller: "allReportController"
                                     }
-                                }
+                                },
+                                //authorize the user
+                                onEnter : function(authFactory) {
+									authFactory.authReports();
+								}
                             }
                         )
 				});

--- a/caliber/src/main/webapp/static/app/resources/js/config/routeConfig.js
+++ b/caliber/src/main/webapp/static/app/resources/js/config/routeConfig.js
@@ -100,7 +100,7 @@ angular
 												templateUrl : "/static/app/partials/manage/trainee-axillary-modals.html"
 											}
 										},
-										//authorize the user
+										// authorize the user
 										onEnter : function(authFactory) {
 											authFactory.authManage();
 										}
@@ -119,7 +119,7 @@ angular
 												templateUrl : "/static/app/partials/assess/confirm-add-weeks-modal.html"
 											}
 										},
-										//authorize the user
+										// authorize the user
 										onEnter : function(authFactory) {
 											authFactory.authAudit();
 										}
@@ -152,7 +152,7 @@ angular
 												controller : "qcAssessController"
 											}
 										},
-										//authorize the user
+										// authorize the user
 										onEnter : function(authFactory) {
 											authFactory.authReports();
 										}
@@ -232,7 +232,7 @@ angular
 												templateUrl : "/static/app/partials/manage/trainee-axillary-modals.html"
 											}
 										},
-										//authorize the user
+										// authorize the user
 										onEnter : function(authFactory) {
 											authFactory.authManage();
 										}
@@ -255,7 +255,7 @@ angular
 
 											}
 										},
-										//authorize the user
+										// authorize the user
 										onEnter : function(authFactory) {
 											authFactory.authAssess();
 										}
@@ -287,7 +287,7 @@ angular
 												controller : "qcAssessController"
 											}
 										},
-										//authorize the user
+										// authorize the user
 										onEnter : function(authFactory) {
 											authFactory.authReports();
 										}
@@ -359,7 +359,7 @@ angular
 												templateUrl : "/static/app/partials/trainers/trainer-auxillary-modals.html"
 											}
 										},
-										//authorize the users
+										// authorize the users
 										onEnter : function(authFactory) {
 											authFactory.authTrainers();
 										},
@@ -382,7 +382,7 @@ angular
 												templateUrl : "/static/app/partials/category/edit-category-modals.html"
 											}
 										},
-										//authorize the user
+										// authorize the user
 										onEnter : function(authFactory) {
 											authFactory.authCategory();
 										}
@@ -417,7 +417,7 @@ angular
 												templateUrl : "/static/app/partials/manage/trainee-axillary-modals.html"
 											}
 										},
-										//authorize the user
+										// authorize the user
 										onEnter : function(authFactory) {
 											authFactory.authManage();
 										}
@@ -442,7 +442,7 @@ angular
 
 											}
 										},
-										//authorize the user
+										// authorize the user
 										onEnter : function(authFactory) {
 											authFactory.authAssess();
 										}
@@ -467,7 +467,7 @@ angular
 
 											}
 										},
-										//authorize the user
+										// authorize the user
 										onEnter : function(authFactory) {
 											authFactory.authAudit();
 										}
@@ -499,7 +499,7 @@ angular
 												controller : "qcAssessController"
 											}
 										},
-										//authorize the user
+										// authorize the user
 										onEnter : function(authFactory) {
 											authFactory.authReports();
 										}
@@ -507,10 +507,11 @@ angular
 									})
 
                             /**
-                             * Staging role
-                             *
-                             * Reusing qc's controllers because staging and qc are the same except for access to some states
-                             */
+							 * Staging role
+							 * 
+							 * Reusing qc's controllers because staging and qc
+							 * are the same except for access to some states
+							 */
                         .state("staging",
                             {
                                 abstract: true,
@@ -534,7 +535,9 @@ angular
                             {
                                 templateUrl: "/static/app/partials/home/staging-home.html",
                                 url: "/home",
-                                controller: "qcHomeController" // because they are similar roles
+                                controller: "qcHomeController" // because they
+																// are similar
+																// roles
                             }
                         )
 
@@ -547,7 +550,7 @@ angular
                                         controller: "allReportController"
                                     }
                                 },
-                                //authorize the user
+                                // authorize the user
                                 onEnter : function(authFactory) {
 									authFactory.authReports();
 								}

--- a/caliber/src/main/webapp/static/app/resources/js/factories/authFactory.js
+++ b/caliber/src/main/webapp/static/app/resources/js/factories/authFactory.js
@@ -189,6 +189,7 @@ angular.module("auth").factory("authFactory",
 		        			break;
 		        		case stagingRole:
 		        			$log.debug("Changing state to: " + stagingReports);
+		        			break;
 		        		default:
 		        			auth.auth();
 	        		}

--- a/caliber/src/main/webapp/static/app/resources/js/factories/authFactory.js
+++ b/caliber/src/main/webapp/static/app/resources/js/factories/authFactory.js
@@ -22,6 +22,25 @@ angular.module("auth").factory("authFactory",
 			var vpHome = "/vp/home";
 			var qcHome = "/qc/home";
 			var trainerHome = "/trainer/home";
+			
+			var vpManage = "vp.manage";
+			var qcManage = "qc.manage";
+			var trainerManage = "trainer.manage";
+			
+			var vpAudit = "vp.audit";
+			var qcAudit = "qc.audit";
+			
+			var vpReports = "vp.reports";
+			var qcReports = "qc.reports";
+			var trainerReports = "trainer.reports";
+			
+			var trainerImport = "trainer.import";
+			
+			var vpAssess = "vp.assess";
+			var trainerAssess = "trainer.assess";
+			
+			var vpCategory = "vp.category";
+			var vpTrainers = "vp.trainers";
 
 			/**
 			 * Retrieves role from cookie

--- a/caliber/src/main/webapp/static/app/resources/js/factories/authFactory.js
+++ b/caliber/src/main/webapp/static/app/resources/js/factories/authFactory.js
@@ -25,7 +25,7 @@ angular.module("auth").factory("authFactory",
 			
 			var vpManage = "vp.manage";
 			var qcManage = "qc.manage";
-			var trainerManage = "trainer.manage";
+			var trainerManage = "/trainer/home";
 			
 			var vpAudit = "vp.audit";
 			var qcAudit = "qc.audit";
@@ -33,6 +33,7 @@ angular.module("auth").factory("authFactory",
 			var vpReports = "vp.reports";
 			var qcReports = "qc.reports";
 			var trainerReports = "trainer.reports";
+			var stagingReports = "staging.reports";
 			
 			var trainerImport = "trainer.import";
 			
@@ -40,6 +41,7 @@ angular.module("auth").factory("authFactory",
 			var trainerAssess = "trainer.assess";
 			
 			var vpCategory = "vp.category";
+			
 			var vpTrainers = "vp.trainers";
 
 			/**
@@ -88,7 +90,7 @@ angular.module("auth").factory("authFactory",
 					$log.debug("Authenticated user as QC");
 				else if (role === trainerRole)
 					$location.path(trainerHome);
-				else
+				else if (role === vpRole)
 					$location.path(vpHome);
 			};
 
@@ -103,7 +105,7 @@ angular.module("auth").factory("authFactory",
 					$log.debug("Authenticate user as VP");
 				else if (role === trainerRole)
 					$location.path(trainerHome);
-				else
+				else if (role === qcRole)
 					$location.path(qcHome);
 			};
 
@@ -116,7 +118,7 @@ angular.module("auth").factory("authFactory",
 					$log.debug("Authenticated user as Trainer");
 				else if (role === qcRole)
 					$location.path(qcHome);
-				else
+				else if (role === vpRole)
 					$location.path(vpHome);
 			};
 
@@ -132,6 +134,124 @@ angular.module("auth").factory("authFactory",
                 		$location.path("/");
                 }
             };
+            
+            /* if user has one of the specified roles, continue on. Otherwise,
+             * take the user to his/her homepage. */
+            auth.authManage = function() {
+            		var role = getCookie();
+            		
+            		switch(role) {
+	            		case vpRole:
+	            			$log.debug("Changing state to: " + vpManage);
+	            			break;
+	            		case qcRole:
+	            			$log.debug("Changing state to: " + qcManage);
+	            			break;
+	            		case trainerRole:
+	            			$log.debug("Changing state to: " + trainerManage);
+	            			break;
+	            		default:
+	            			auth.auth();
+            		}
+            };
+            
+            /* if user has one of the specified roles, continue on. Otherwise,
+             * take the user to his/her homepage. */
+            auth.authAudit = function() {
+				var role = getCookie();
 
+                switch (role) {
+	                case vpRole:
+	                    $log.debug("Changing state to: " + vpAudit);
+						break;
+					case qcRole:
+                        $log.debug("Changing state to: " + qcAudit);
+						break;
+					default:
+						auth.auth();
+                }
+			};
+			
+			/* if user has one of the specified roles, continue on. Otherwise,
+             * take the user to his/her homepage. */
+			auth.authReports = function() {
+	        		var role = getCookie();
+	        		
+	        		switch(role) {
+		        		case vpRole:
+		        			$log.debug("Changing state to: " + vpReports);
+		        			break;
+		        		case qcRole:
+		        			$log.debug("Changing state to: " + qcReports);
+		        			break;
+		        		case trainerRole:
+		        			$log.debug("Changing state to: " + trainerReports);
+		        			break;
+		        		case stagingRole:
+		        			$log.debug("Changing state to: " + stagingReports);
+		        		default:
+		        			auth.auth();
+	        		}
+        };
+        
+        /* if user has one of the specified roles, continue on. Otherwise,
+         * take the user to his/her homepage. */
+        auth.authImport = function() {
+	        	var role = getCookie();
+	    		
+	    		switch(role) {
+		    		case trainerRole:
+		    			$log.debug("Changing state to: " + trainerImport);
+		    			break;
+		    		default:
+		    			auth.auth();
+	    		}
+        };
+        
+        /* if user has one of the specified roles, continue on. Otherwise,
+         * take the user to his/her homepage. */
+        auth.authAssess = function() {
+	        	var role = getCookie();
+	    		
+	    		switch(role) {
+		    		case vpRole:
+		    			$log.debug("Changing state to: " + vpAssess);
+		    			break;
+		    		case trainerRole:
+		    			$log.debug("Changing state to: " + trainerAssess);
+		    			break;
+		    		default:
+		    			auth.auth();
+	    		}
+        };
+        
+        /* if user has one of the specified roles, continue on. Otherwise,
+         * take the user to his/her homepage. */
+        auth.authCategory = function() {
+        		var role = getCookie();
+        		
+        		switch(role) {
+	        		case vpRole:
+	        			$log.debug("Changing state to: " + vpCategory);
+	        			break;
+	        		default:
+	        			auth.auth();
+        		}
+        };
+        
+        /* if user has one of the specified roles, continue on. Otherwise,
+         * take the user to his/her homepage. */
+        auth.authTrainers = function() {
+        		var role = getCookie();
+        		
+        		switch(role) {
+	        		case vpRole:
+	        			$log.debug("Changing state to: " + vpTrainers);
+	        			break;
+	        		default:
+	        			auth.auth();
+        		}
+        };
+        
 			return auth;
 		});

--- a/caliber/src/main/webapp/static/app/resources/js/factories/authFactory.js
+++ b/caliber/src/main/webapp/static/app/resources/js/factories/authFactory.js
@@ -23,26 +23,26 @@ angular.module("auth").factory("authFactory",
 			var qcHome = "/qc/home";
 			var trainerHome = "/trainer/home";
 			
-//			var vpManage = "vp.manage";
-//			var qcManage = "qc.manage";
-//			var trainerManage = "/trainer/home";
-//			
-//			var vpAudit = "vp.audit";
-//			var qcAudit = "qc.audit";
-//			
-//			var vpReports = "vp.reports";
-//			var qcReports = "qc.reports";
-//			var trainerReports = "trainer.reports";
-//			var stagingReports = "staging.reports";
-//			
-//			var trainerImport = "trainer.import";
-//			
-//			var vpAssess = "vp.assess";
-//			var trainerAssess = "trainer.assess";
-//			
-//			var vpCategory = "vp.category";
-//			
-//			var vpTrainers = "vp.trainers";
+			var vpManage = "vp.manage";
+			var qcManage = "qc.manage";
+			var trainerManage = "/trainer/home";
+			
+			var vpAudit = "vp.audit";
+			var qcAudit = "qc.audit";
+			
+			var vpReports = "vp.reports";
+			var qcReports = "qc.reports";
+			var trainerReports = "trainer.reports";
+			var stagingReports = "staging.reports";
+			
+			var trainerImport = "trainer.import";
+			
+			var vpAssess = "vp.assess";
+			var trainerAssess = "trainer.assess";
+			
+			var vpCategory = "vp.category";
+			
+			var vpTrainers = "vp.trainers";
 
 			/**
 			 * Retrieves role from cookie

--- a/caliber/src/main/webapp/static/app/resources/js/factories/authFactory.js
+++ b/caliber/src/main/webapp/static/app/resources/js/factories/authFactory.js
@@ -22,26 +22,26 @@ angular.module("auth").factory("authFactory",
 			var vpHome = "/vp/home";
 			var qcHome = "/qc/home";
 			var trainerHome = "/trainer/home";
-			
+
 			var vpManage = "vp.manage";
 			var qcManage = "qc.manage";
 			var trainerManage = "/trainer/home";
-			
+
 			var vpAudit = "vp.audit";
 			var qcAudit = "qc.audit";
-			
+
 			var vpReports = "vp.reports";
 			var qcReports = "qc.reports";
 			var trainerReports = "trainer.reports";
 			var stagingReports = "staging.reports";
-			
+
 			var trainerImport = "trainer.import";
-			
+
 			var vpAssess = "vp.assess";
 			var trainerAssess = "trainer.assess";
-			
+
 			var vpCategory = "vp.category";
-			
+
 			var vpTrainers = "vp.trainers";
 
 			/**
@@ -61,24 +61,24 @@ angular.module("auth").factory("authFactory",
 			auth.auth = function() {
 				var role = getCookie();
 
-                switch (role) {
-					case trainerRole:
-					    $log.debug("Changing state to: " + trainerState);
-						$state.go(trainerState);
-						break;
-					case qcRole:
-                        $log.debug("Changing state to: " + qcState);
-						$state.go(qcState);
-						break;
-					case vpRole:
-                        $log.debug("Changing state to: " + vpState);
-						$state.go(vpState);
-						break;
-					case stagingRole:
-                        $log.debug("Changing state to: " + stagingState);
-						$state.go(stagingState);
-						break;
-                }
+				switch (role) {
+				case trainerRole:
+					$log.debug("Changing state to: " + trainerState);
+					$state.go(trainerState);
+					break;
+				case qcRole:
+					$log.debug("Changing state to: " + qcState);
+					$state.go(qcState);
+					break;
+				case vpRole:
+					$log.debug("Changing state to: " + vpState);
+					$state.go(vpState);
+					break;
+				case stagingRole:
+					$log.debug("Changing state to: " + stagingState);
+					$state.go(stagingState);
+					break;
+				}
 			};
 
 			/**
@@ -122,137 +122,151 @@ angular.module("auth").factory("authFactory",
 					$location.path(vpHome);
 			};
 
-			auth.authStaging = function () {
+			auth.authStaging = function() {
 				var role = getCookie();
 
-                $log.debug("Authorizing staging role");
+				$log.debug("Authorizing staging role");
 
-                if(role !== stagingRole) {
-                	if (devMode)
-                		$location.path(DEBUG_URL);
-                	else
-                		$location.path("/");
-                }
-            };
-            
-            /* if user has one of the specified roles, continue on. Otherwise,
-             * take the user to his/her homepage. */
-            auth.authManage = function() {
-            		var role = getCookie();
-            		
-            		switch(role) {
-	            		case vpRole:
-	            			$log.debug("Changing state to: " + vpManage);
-	            			break;
-	            		case qcRole:
-	            			$log.debug("Changing state to: " + qcManage);
-	            			break;
-	            		case trainerRole:
-	            			$log.debug("Changing state to: " + trainerManage);
-	            			break;
-	            		default:
-	            			auth.auth();
-            		}
-            };
-            
-            /* if user has one of the specified roles, continue on. Otherwise,
-             * take the user to his/her homepage. */
-            auth.authAudit = function() {
-				var role = getCookie();
-
-                switch (role) {
-	                case vpRole:
-	                    $log.debug("Changing state to: " + vpAudit);
-						break;
-					case qcRole:
-                        $log.debug("Changing state to: " + qcAudit);
-						break;
-					default:
-						auth.auth();
-                }
+				if (role !== stagingRole) {
+					if (devMode)
+						$location.path(DEBUG_URL);
+					else
+						$location.path("/");
+				}
 			};
-			
-			/* if user has one of the specified roles, continue on. Otherwise,
-             * take the user to his/her homepage. */
+
+			/*
+			 * if user has one of the specified roles, continue on. Otherwise,
+			 * take the user to his/her homepage.
+			 */
+			auth.authManage = function() {
+				var role = getCookie();
+
+				switch (role) {
+				case vpRole:
+					$log.debug("Changing state to: " + vpManage);
+					break;
+				case qcRole:
+					$log.debug("Changing state to: " + qcManage);
+					break;
+				case trainerRole:
+					$log.debug("Changing state to: " + trainerManage);
+					break;
+				default:
+					auth.auth();
+				}
+			};
+
+			/*
+			 * if user has one of the specified roles, continue on. Otherwise,
+			 * take the user to his/her homepage.
+			 */
+			auth.authAudit = function() {
+				var role = getCookie();
+
+				switch (role) {
+				case vpRole:
+					$log.debug("Changing state to: " + vpAudit);
+					break;
+				case qcRole:
+					$log.debug("Changing state to: " + qcAudit);
+					break;
+				default:
+					auth.auth();
+				}
+			};
+
+			/*
+			 * if user has one of the specified roles, continue on. Otherwise,
+			 * take the user to his/her homepage.
+			 */
 			auth.authReports = function() {
-	        		var role = getCookie();
-	        		
-	        		switch(role) {
-		        		case vpRole:
-		        			$log.debug("Changing state to: " + vpReports);
-		        			break;
-		        		case qcRole:
-		        			$log.debug("Changing state to: " + qcReports);
-		        			break;
-		        		case trainerRole:
-		        			$log.debug("Changing state to: " + trainerReports);
-		        			break;
-		        		case stagingRole:
-		        			$log.debug("Changing state to: " + stagingReports);
-		        			break;
-		        		default:
-		        			auth.auth();
-	        		}
-        };
-        
-        /* if user has one of the specified roles, continue on. Otherwise,
-         * take the user to his/her homepage. */
-        auth.authImport = function() {
-	        	var role = getCookie();
-	    		
-	    		switch(role) {
-		    		case trainerRole:
-		    			$log.debug("Changing state to: " + trainerImport);
-		    			break;
-		    		default:
-		    			auth.auth();
-	    		}
-        };
-        
-        /* if user has one of the specified roles, continue on. Otherwise,
-         * take the user to his/her homepage. */
-        auth.authAssess = function() {
-	        	var role = getCookie();
-	    		
-	    		switch(role) {
-		    		case vpRole:
-		    			$log.debug("Changing state to: " + vpAssess);
-		    			break;
-		    		case trainerRole:
-		    			$log.debug("Changing state to: " + trainerAssess);
-		    			break;
-		    		default:
-		    			auth.auth();
-	    		}
-        };
-        
-        /* if user has one of the specified roles, continue on. Otherwise,
-         * take the user to his/her homepage. */
-        auth.authCategory = function() {
-        		var role = getCookie();
-        		
-        		switch(role) {
-	        		case vpRole:
-	        			$log.debug("Changing state to: " + vpCategory);
-	        			break;
-	        		default:
-	        			auth.auth();
-        		}
-        };
-        
-        /* if user has one of the specified roles, continue on. Otherwise,
-         * take the user to his/her homepage. */
-        auth.authTrainers = function() {
-        		var role = getCookie();
-        		
-        		switch(role) {
-	        		case vpRole:
-	        			$log.debug("Changing state to: " + vpTrainers);
-	        			break;
-	        		default:
-	        			auth.auth();
-        		}
-        };
-        
+				var role = getCookie();
+
+				switch (role) {
+				case vpRole:
+					$log.debug("Changing state to: " + vpReports);
+					break;
+				case qcRole:
+					$log.debug("Changing state to: " + qcReports);
+					break;
+				case trainerRole:
+					$log.debug("Changing state to: " + trainerReports);
+					break;
+				case stagingRole:
+					$log.debug("Changing state to: " + stagingReports);
+					break;
+				default:
+					auth.auth();
+				}
+			};
+
+			/*
+			 * if user has one of the specified roles, continue on. Otherwise,
+			 * take the user to his/her homepage.
+			 */
+			auth.authImport = function() {
+				var role = getCookie();
+
+				switch (role) {
+				case trainerRole:
+					$log.debug("Changing state to: " + trainerImport);
+					break;
+				default:
+					auth.auth();
+				}
+			};
+
+			/*
+			 * if user has one of the specified roles, continue on. Otherwise,
+			 * take the user to his/her homepage.
+			 */
+			auth.authAssess = function() {
+				var role = getCookie();
+
+				switch (role) {
+				case vpRole:
+					$log.debug("Changing state to: " + vpAssess);
+					break;
+				case trainerRole:
+					$log.debug("Changing state to: " + trainerAssess);
+					break;
+				default:
+					auth.auth();
+				}
+			};
+
+			/*
+			 * if user has one of the specified roles, continue on. Otherwise,
+			 * take the user to his/her homepage.
+			 */
+			auth.authCategory = function() {
+				var role = getCookie();
+
+				switch (role) {
+				case vpRole:
+					$log.debug("Changing state to: " + vpCategory);
+					break;
+				default:
+					auth.auth();
+				}
+			};
+
+			/*
+			 * if user has one of the specified roles, continue on. Otherwise,
+			 * take the user to his/her homepage.
+			 */
+			auth.authTrainers = function() {
+				var role = getCookie();
+
+				switch (role) {
+				case vpRole:
+					$log.debug("Changing state to: " + vpTrainers);
+					break;
+				default:
+					auth.auth();
+				}
+			};
+
 			return auth;
 		});


### PR DESCRIPTION
### Purpose of Pull Request
- To add authorization for each endpoint on server-side and client-side.
- On top of the current roles(vp, qc, trainer), the new staging role has been given the appropriate access controls.

### Where should the reviewer start?
## Server-side:
- PreAuthorize annotations are added on top of each Spring controller's methods(except for Bootcontroller's methods)  to give certain roles access to them. The controllers can be found in the 'com.revature.caliber.controllers' package. 
- The use of preauthorize annotation is enabled on lines 42-43 of the spring-security.xml file.

## Client-side:
- On the front-end, authorization is only used for the sake of routing access. 
- In authFactory.js file, a function is implemented for each state which will allow a user to pass through and continue on if user has the specified role. Otherwise, the user will be taken to his/her home page. 
- In routeConfig.js file, the functions mentioned above are applied here with 'onEnter' callback for each state; so, when a user enters this url or 'state', the state becomes active and oneEnter gets called, which in turn, calls our function.

### Any background context you want to provide?
- Spring security is used to accomplish this feat on the server-side.
- UI-router and basic javascript functions are used to accomplish this feat on the client-side.

### What are the relevant stories/issues?
- In the TrainingController class, if a role(s) is assigned with PreAuthorize in the findTrainer method, the site won't load its pages. Thus, role wasn't assigned in this method.

### Screenshots (if appropriate)

### Questions: