### PR TITLE
Hotfix Log4j log files location

### DIFF
--- a/caliber/src/main/resources/log4j.properties
+++ b/caliber/src/main/resources/log4j.properties
@@ -7,19 +7,19 @@ log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.appender.console.layout.ConversionPattern=%-7p %d [%t] %c %x - %m%n
  
 log4j.appender.log=org.apache.log4j.FileAppender
-log4j.appender.log.File=/Users/Dc/Desktop/logs/output.log
+log4j.appender.log.File=/home/ec2-user/caliber/logs/output.log
 log4j.appender.log.layout=org.apache.log4j.PatternLayout
 log4j.appender.log.layout.ConversionPattern=%-7p %d [%t] %c %x - %m%n
 log4j.appender.log.Threshold=WARN
 
 log4j.appender.troubleshoot=org.apache.log4j.FileAppender
-log4j.appender.troubleshoot.File=/Users/Dc/Desktop/logs/troubleshoot.log
+log4j.appender.troubleshoot.File=/home/ec2-user/caliber/logs/troubleshoot.log
 log4j.appender.troubleshoot.layout=org.apache.log4j.PatternLayout
 log4j.appender.troubleshoot.layout.ConversionPattern=%-7p %d [%t] %c %x - %m%n
 log4j.appender.troubleshoot.Threshold=ERROR
 
 log4j.appender.extreme=org.apache.log4j.FileAppender
-log4j.appender.extreme.File=/Users/Dc/Desktop/logs/extreme.log
+log4j.appender.extreme.File=/home/ec2-user/caliber/logs/extreme.log
 log4j.appender.extreme.layout=org.apache.log4j.PatternLayout
 log4j.appender.extreme.layout.ConversionPattern=%-7p %d [%t] %c %x - %m%n
 log4j.appender.extreme.Threshold=FATAL


### PR DESCRIPTION
### Purpose of Pull Request
The current setup doesn't create log files for Mac users. Changing back to previous iteration's setup.

### Where should the reviewer start?
caliber/src/main/resources/log4j.properties

### Any background context you want to provide?
The current setup doesn't create log files for Mac users.

### What are the relevant stories/issues?
Local setup will throw error for Mac users.

### Screenshots (if appropriate)

### Questions: