### PR TITLE
Fixed chart stack-up and tooltip order. Reversed order of the labels.

### DIFF
--- a/caliber/src/main/webapp/static/app/resources/js/factories/chartFactories/barChartFactory.js
+++ b/caliber/src/main/webapp/static/app/resources/js/factories/chartFactories/barChartFactory.js
@@ -263,16 +263,16 @@ angular.module("charts").factory(
 					angular.forEach(batch.qcStatus, function(value2, key2) {
 						// Because the qcStatuses get randomized, this if else set orders them.
 						if(key2 === "Poor"){
-							i = 3;
+							i = 0;
 						}
 						else if(key2 === "Average"){
-							i = 2;
-						}
-						else if(key2 === "Good"){
 							i = 1;
 						}
+						else if(key2 === "Good"){
+							i = 2;
+						}
 						else if(key2 === "Superstar"){
-							i = 0;
+							i = 3;
 						}
 						if (chartData.data[i] === undefined) {
 							chartData.data[i]=[];
@@ -303,12 +303,14 @@ angular.module("charts").factory(
 							boxWidth : 10
 						}
 					},
+					tooltips: { 
+						itemSort: function(a, b) { return b.datasetIndex - a.datasetIndex }
+					},
 					scales : {
 						yAxes : [ {
 							stacked : true,
 							ticks : {
-								mirror : true,
-								reverse: true
+								mirror : true
 							}
 						} ],
 						xAxes : [ {


### PR DESCRIPTION
### Purpose of Pull Request
To fix the order of the stacked bar charts on the QC/VP home page.
### Where should the reviewer start?
caliber/src/main/webapp/static/app/resources/js/factories/chartFactories/barChartFactory.js
### Any background context you want to provide?
After showing you the little demo, I noticed that the hover over tooltip was stacked wrong too.
That is now fixed with this patch as well.
### What are the relevant stories/issues?
Issue/648
### Screenshots (if appropriate)

### Questions: