### PR TITLE
Issue/#616: Searching on reports pages

### DIFF
--- a/caliber/src/main/resources/spring-security.xml
+++ b/caliber/src/main/resources/spring-security.xml
@@ -12,7 +12,7 @@ http://www.springframework.org/schema/security/spring-security.xsd">
 		<security:form-login login-page="/" />
 
 		<!-- enable SSL -->
-		<security:intercept-url pattern="/**" requires-channel="https" />
+		<!-- <security:intercept-url pattern="/**" requires-channel="https" />  -->
 
 
 		<!-- change to hasRole('ROLE_VP') after development is complete -->

--- a/caliber/src/main/webapp/static/app/partials/reports.html
+++ b/caliber/src/main/webapp/static/app/partials/reports.html
@@ -24,10 +24,10 @@
                 <form ng-submit="selectChosenTrainee()">
                     <span class="icon"><button type="submit" class="SearchButton"><i class="fa fa-search"></i></button></span>
                       <input ng-model="chosenTrainee" list="traineeList" type="search" id="searchTextBox" 
-                      		placeholder="Search..." class="form-control SearchPad" autocomplete="on" />
+                      		placeholder="Search..." class="form-control SearchPad" autocomplete="off" />
                       <datalist id="traineeList">
 	    						<option ng-repeat="trainee in allTrainees track by $index" ng-value="trainee.name">
-	    							{{trainee.email}} | {{trainee.skypeId}} 
+	    							{{trainee.name}} | {{trainee.email}} | {{trainee.skypeId}} 
 	    						</option>
 	    			  </datalist>
                 </form>

--- a/caliber/src/main/webapp/static/app/partials/reports.html
+++ b/caliber/src/main/webapp/static/app/partials/reports.html
@@ -23,10 +23,11 @@
 			<div class="container-1 pull-right">
                 <form ng-submit="selectChosenTrainee()">
                     <span class="icon"><button type="submit" class="SearchButton"><i class="fa fa-search"></i></button></span>
-                      <input ng-model="chosenTrainee" list="traineeList" type="search" id="searchTextBox" placeholder="Search..." class="form-control SearchPad" />
+                      <input ng-model="chosenTrainee" list="traineeList" type="search" id="searchTextBox" 
+                      		placeholder="Search..." class="form-control SearchPad" autocomplete="on" />
                       <datalist id="traineeList">
 	    						<option ng-repeat="trainee in allTrainees track by $index" ng-value="trainee.name">
-	    							
+	    							{{trainee.email}} | {{trainee.skypeId}} 
 	    						</option>
 	    			  </datalist>
                 </form>

--- a/caliber/src/main/webapp/static/app/partials/reports.html
+++ b/caliber/src/main/webapp/static/app/partials/reports.html
@@ -18,6 +18,19 @@
 					<li><a href="" ng-click="generatePDF()"> Charts + Feedback </a></li>
 				</ul>
 			</div>
+			
+			<!-- Search for single Trainee -->
+			<div class="container-1 pull-right">
+                <form ng-submit="selectChosenTrainee()">
+                    <span class="icon"><button type="submit" class="SearchButton"><i class="fa fa-search"></i></button></span>
+                      <input ng-model="chosenTrainee" list="traineeList" type="search" id="searchTextBox" placeholder="Search..." class="form-control SearchPad" />
+                      <datalist id="traineeList">
+	    						<option ng-repeat="trainee in allTrainees track by $index" ng-value="trainee.name">
+	    							
+	    						</option>
+	    			  </datalist>
+                </form>
+            </div>
 
 			<ul class="nav nav-tabs">
 				<!-- Filter batches by year -->
@@ -56,8 +69,9 @@
 						<li><a role="button" ng-click="selectCurrentTrainee(-1)">All</a></li>
 						<li ng-repeat="trainee in currentBatch.trainees track by $index"><a
 							role="button" ng-click="selectCurrentTrainee($index)">{{trainee.name}}</a></li>
-					</ul></li>
-
+					</ul>
+				</li>
+				
 				<!-- Select Training Type-->
 						<!-- 	<li role="button" class="dropdown"><a
 								class="dropdown-toggle" data-toggle="dropdown"> Training

--- a/caliber/src/main/webapp/static/app/resources/css/app.css
+++ b/caliber/src/main/webapp/static/app/resources/css/app.css
@@ -528,3 +528,34 @@ INTENDED FOR CHART DOWNLOAD ICON IF HOVER OVER CHANGE CURSOR TO POINTING
 .clickableIcons {
 	cursor: pointer;
 }
+
+.container-1{
+  width: 300px;
+  vertical-align: middle;
+  white-space: nowrap;
+  position: relative;
+}
+
+.container-1 .icon{
+  position: absolute;
+  bottom: 0%;
+  right: 0%;
+  margin-left: 17px;
+  margin-top: 17px;
+  z-index: 1;
+  color: grey;
+}
+
+.SearchPad {
+    padding-right: 40px;
+}
+
+.SearchButton {
+    background-color: Transparent;
+    border: none;
+    padding-right: 30px;
+    height: 34px;
+    width: 35px;
+    overflow: hidden;
+    outline:none;
+}

--- a/caliber/src/main/webapp/static/app/resources/js/controllers/allReportController.js
+++ b/caliber/src/main/webapp/static/app/resources/js/controllers/allReportController.js
@@ -9,440 +9,483 @@
  * 
  */
 angular
-		.module("charts")
-		.controller(
-				"allReportController",
-				function($rootScope, $scope, $state, $log, caliberDelegate,
-						chartsDelegate, allBatches) {
+.module("charts")
+.controller(
+		"allReportController",
+		function($rootScope, $scope, $state, $log, caliberDelegate,
+				chartsDelegate, allBatches) {
 
-					// *******************************************************************************
-					// *** UI
-					// *******************************************************************************
+			// *******************************************************************************
+			// *** UI
+			// *******************************************************************************
 
-					const
-					OVERALL = "(All)";
-					const
-					ALL = -1;
-					var radarComparData = null;
-					var radarComparObj = {};
-					
-					// What you see when you open Reports
-					var startingDate = new Date();
-					startingDate.setFullYear(startingDate.getFullYear() - 1);
-					$scope.startDate = startingDate;
-					$scope.selectedTrainingType = OVERALL;
-					$scope.selectedSkill = OVERALL;
-					$scope.currentBatch = allBatches[0];
-					$scope.reportCurrentWeek = OVERALL;
-					$scope.currentBatchWeeks = [];
-					$scope.skillstack = [];
-					$scope.trainingTypes = [];
-					$scope.currentTraineeId = ALL;
-					$scope.noBatch = true;
-					$scope.batchWeek = false;
-					$scope.batchWeekTrainee = false;
-					$scope.batchOverall = false;
-					$scope.batchOverallTrainee = false;
+			const
+			OVERALL = "(All)";
+			const
+			ALL = -1;
+			var radarComparData = null;
+			var radarComparObj = {};
 
-					(function() {
-						// Finishes any left over ajax animation
-						NProgress.done();
-						// get stack of batch skill
-						 getAllSkillTypes();
-						// get all training types for dropdown
-						getAllTrainingTypes();
+			// What you see when you open Reports
+			var startingDate = new Date();
+			startingDate.setFullYear(startingDate.getFullYear() - 1);
+			$scope.startDate = startingDate;
+			$scope.selectedTrainingType = OVERALL;
+			$scope.selectedSkill = OVERALL;
+			$scope.currentBatch = allBatches[0];
+			$scope.reportCurrentWeek = OVERALL;
+			$scope.currentBatchWeeks = [];
+			$scope.skillstack = [];
+			$scope.trainingTypes = [];
+			$scope.currentTraineeId = ALL;
+			$scope.noBatch = true;
+			$scope.batchWeek = false;
+			$scope.batchWeekTrainee = false;
+			$scope.batchOverall = false;
+			$scope.batchOverallTrainee = false;
+			$scope.allTrainees = [];
+			
+			
+			
+			
+			//load $scope.trainees list for search results
+			function getTrainees(){
+				//for each batch, add the trainees to an overall list of trainees
+				allBatches.forEach(function(batch){
+					batch.trainees.forEach(function(trainee){
+						$scope.allTrainees.push(trainee);
+					});
+				});
+			}
 
-						if ($scope.currentBatch === null || $scope.currentBatch === undefined) {
-							$scope.noBatch = true;
-							$log.debug("You have no batches");
-						} else {
-							$log.debug("You have some batches");
-							$scope.noBatch = false;
+			
+			//load chart information based on chosen searched trainee
+			$scope.selectChosenTrainee = function(){
+				//get name
+				var traineeName = $scope.chosenTrainee;
+				//get trainee and batch
+				allBatches.forEach(function(batch){
+					batch.trainees.forEach(function(trainee){
+						if(trainee.name == traineeName){
+							//set view search defaults
+							$scope.reportCurrentWeek = '(All)';
+							$scope.currentBatch = batch;
+							$scope.currentTrainee = trainee;
+							$scope.currentTraineeId = trainee.traineeId;
 							$scope.selectedYear = Number($scope.currentBatch.startDate
 									.substr(0, 4));
-							batchYears();
 							getCurrentBatchWeeks($scope.currentBatch.weeks);
+
+							//set view
 							selectView($scope.currentBatch.batchId,
 									$scope.reportCurrentWeek,
 									$scope.currentTraineeId);
+							return;
 						}
+					});
+				});
+			};
 
-					})();
-					
-					function selectView(batch, week, trainee) {
-						if (week === OVERALL) {
-							// All Weeks
-							if (trainee === ALL) {
-								// All Trainees
-								$scope.batchWeek = false;
-								$scope.batchWeekTrainee = false;
-								$scope.batchOverall = true;
-								$scope.batchOverallTrainee = false;
-								createBatchOverall();
+			(function() {
+				// Finishes any left over ajax animation
+				NProgress.done();
+				// get stack of batch skill
+				getAllSkillTypes();
+				// get all training types for dropdown
+				getAllTrainingTypes();
+				// get all trainees for search results display
 
-							} else {
-								// Specific Trainee
-								$rootScope.$emit("GET_TRAINEE_OVERALL",
-										$scope.currentTraineeId);
-								displayTraineeOverallTable($scope.currentTraineeId);
-								$scope.batchWeek = false;
-								$scope.batchWeekTrainee = false;
-								$scope.batchOverall = false;
-								$scope.batchOverallTrainee = true;
-								createBatchOverallTrainee();
+				if ($scope.currentBatch === null || $scope.currentBatch === undefined) {
+					$scope.noBatch = true;
+					$log.debug("You have no batches");
+				} else {
+					$log.debug("You have some batches");
+					$scope.noBatch = false;
+					$scope.selectedYear = Number($scope.currentBatch.startDate
+							.substr(0, 4));
+					batchYears();
+					getCurrentBatchWeeks($scope.currentBatch.weeks);
+					selectView($scope.currentBatch.batchId,
+							$scope.reportCurrentWeek,
+							$scope.currentTraineeId);
+				}
+
+			})();
+
+			function selectView(batch, week, trainee) {
+				if (week === OVERALL) {
+					// All Weeks
+					if (trainee === ALL) {
+						// All Trainees
+						$scope.batchWeek = false;
+						$scope.batchWeekTrainee = false;
+						$scope.batchOverall = true;
+						$scope.batchOverallTrainee = false;
+						createBatchOverall();
+
+					} else {
+						// Specific Trainee
+						$rootScope.$emit("GET_TRAINEE_OVERALL",
+								$scope.currentTraineeId);
+						displayTraineeOverallTable($scope.currentTraineeId);
+						$scope.batchWeek = false;
+						$scope.batchWeekTrainee = false;
+						$scope.batchOverall = false;
+						$scope.batchOverallTrainee = true;
+						createBatchOverallTrainee();
+					}
+				} else {
+					// Specific Week
+					if (trainee === ALL) {
+						// All Trainees
+						$rootScope.$emit('test');
+						$scope.batchWeek = true;
+						$scope.batchWeekTrainee = false;
+						$scope.batchOverall = false;
+						$scope.batchOverallTrainee = false;
+						createBatchWeek();
+					} else {
+						// Specific trainee
+						$scope.batchWeek = false;
+						$scope.batchWeekTrainee = true;
+						$scope.batchOverall = false;
+						$scope.batchOverallTrainee = false;
+						createBatchWeekTrainee();
+						$scope.getTraineeNote($scope.currentTraineeId,$scope.currentWeek);
+					}
+
+				}
+
+			}
+			function getAllSkillTypes(){
+				caliberDelegate.all.enumSkillType().then(function(skills){
+					$scope.skillstack= skills;
+					$log.debug($scope.skillstack);
+					$log.debug("Hello there" );
+				});
+
+			}
+
+			function displayTraineeOverallTable(traineeId) {
+				$scope.traineeOverall=[];
+				$scope.categories=[];
+
+				for(const weekNum in $scope.currentBatchWeeks){
+					var week = parseInt(weekNum) + 1;
+					$scope.traineeOverall.push({week});
+					// Daniel get categories for the week
+					// Push a promise to keep order of categories for
+					// each week
+					$scope.categories.push(caliberDelegate.qc.getAllAssessmentCategories(
+							$scope.currentBatch.batchId,
+							week));
+				}
+
+				caliberDelegate.all
+				.getAllTraineeNotes(traineeId)
+				.then(
+						function(response) {
+							if(response !== undefined){
+								for(const note of response){
+									if($scope.traineeOverall[parseInt(note.week)-1] !==undefined){
+										$scope.traineeOverall[parseInt(note.week)-1].trainerNote = note;
+									}
+								}							
 							}
-						} else {
-							// Specific Week
-							if (trainee === ALL) {
-								// All Trainees
-								$rootScope.$emit('test');
-								$scope.batchWeek = true;
-								$scope.batchWeekTrainee = false;
-								$scope.batchOverall = false;
-								$scope.batchOverallTrainee = false;
-								createBatchWeek();
-							} else {
-								// Specific trainee
-								$scope.batchWeek = false;
-								$scope.batchWeekTrainee = true;
-								$scope.batchOverall = false;
-								$scope.batchOverallTrainee = false;
-								createBatchWeekTrainee();
-								$scope.getTraineeNote($scope.currentTraineeId,$scope.currentWeek);
+						});
+				// Daniel get qc notes for the batch for the week
+				caliberDelegate.qc.
+				traineeOverallNote(traineeId)
+				.then(
+						function(response) {
+							for(const qcNote of response){
+								if($scope.traineeOverall[parseInt(qcNote.week)-1] !== undefined){
+									$scope.traineeOverall[parseInt(qcNote.week)-1].qcNote = qcNote;
+								}
 							}
+						});
+			}
 
-						}
+			function getCurrentBatchWeeks(weeks) {
+				$scope.currentBatchWeeks = [];
+				for (var i = 1; i <= weeks; i++)
+					$scope.currentBatchWeeks.push(i);
+			}
 
-					}
-					function getAllSkillTypes(){
-						caliberDelegate.all.enumSkillType().then(function(skills){
-							$scope.skillstack= skills;
-							$log.debug($scope.skillstack);
-							$log.debug("Hello there" );
-							});
-						
-					}
-					
-					function displayTraineeOverallTable(traineeId) {
-						$scope.traineeOverall=[];
-						$scope.categories=[];
-						
-						for(const weekNum in $scope.currentBatchWeeks){
-							var week = parseInt(weekNum) + 1;
-							$scope.traineeOverall.push({week});
-							// Daniel get categories for the week
-							// Push a promise to keep order of categories for
-							// each week
-							$scope.categories.push(caliberDelegate.qc.getAllAssessmentCategories(
-									$scope.currentBatch.batchId,
-									week));
-						}
-						
-						caliberDelegate.all
-								.getAllTraineeNotes(traineeId)
-								.then(
-										function(response) {
-											if(response !== undefined){
-												for(const note of response){
-													if($scope.traineeOverall[parseInt(note.week)-1] !==undefined){
-														$scope.traineeOverall[parseInt(note.week)-1].trainerNote = note;
-													}
-												}							
-											}
-										});
-						// Daniel get qc notes for the batch for the week
-						caliberDelegate.qc.
-								traineeOverallNote(traineeId)
-								.then(
-										function(response) {
-											for(const qcNote of response){
-												if($scope.traineeOverall[parseInt(qcNote.week)-1] !== undefined){
-													$scope.traineeOverall[parseInt(qcNote.week)-1].qcNote = qcNote;
-												}
-											}
-										});
-					}
+			// Filter batches by year
+			$scope.years = addYears();
+			$scope.batches = allBatches;
 
-					function getCurrentBatchWeeks(weeks) {
-						$scope.currentBatchWeeks = [];
-						for (var i = 1; i <= weeks; i++)
-							$scope.currentBatchWeeks.push(i);
-					}
+			$scope.currentTrainee = {
+					name : "Trainee",
+			}
+			// hide filter tabs
+			$scope.hideOtherTabs = function() {
+				if($scope.currentBatch)
+					return $scope.currentBatch.trainingName !== "Batch";
+			}
 
-					// Filter batches by year
-					$scope.years = addYears();
-					$scope.batches = allBatches;
-					
+			function addYears() {
+				var currentYear = new Date().getFullYear();
+				$scope.selectedYear = currentYear;
+
+				var data = [];
+				// List all years from 2014 --> current year
+				for (var y = currentYear + 1; y >= currentYear - 2; y--) {
+					data.push(y)
+				}
+				return data;
+			}
+			function batchYears() {
+				$scope.batchesByYear = [];
+				for (var i = 0; i < allBatches.length; i++) {
+					if ($scope.selectedYear === Number(allBatches[i].startDate
+							.substr(0, 4))) {
+						$scope.batchesByYear.push(allBatches[i]);
+					}
+				}
+			}
+
+			$scope.selectYear = function(index) {
+				$scope.selectedYear = $scope.years[index];
+				sortByDate($scope.selectedYear);
+				batchYears();
+				$scope.currentBatch = $scope.batchesByYear[0];
+				$scope.reportCurrentWeek = OVERALL;
+				$scope.currentTraineeId = ALL;
+				if($scope.currentBatch)
+					selectView($scope.currentBatch.batchId,
+							$scope.reportCurrentWeek,
+							$scope.currentTraineeId);
+			};
+
+			function sortByDate(currentYear) {
+				$scope.selectedBatches = [];
+				for (var i = 0; i < $scope.batches.length; i++) {
+					var date = new Date($scope.batches[i].startDate);
+					if (date.getFullYear() === currentYear) {
+						$scope.selectedBatches.push($scope.batches[i]);
+					}
+				}
+			}
+
+			$scope.selectCurrentBatch = function(index) {
+				$scope.currentBatch = $scope.batchesByYear[index];
+				getCurrentBatchWeeks($scope.currentBatch.weeks);
+				$scope.reportCurrentWeek = OVERALL;
+				$scope.currentTraineeId = ALL;
+				selectView($scope.currentBatch.batchId,
+						$scope.reportCurrentWeek,
+						$scope.currentTraineeId);
+			}
+
+			$scope.selectCurrentWeek = function(week) {
+				$scope.currentWeek = week;
+				$scope.reportCurrentWeek = week;
+				selectView($scope.currentBatch.batchId,
+						$scope.reportCurrentWeek,
+						$scope.currentTraineeId);
+			}
+
+			$scope.selectTrainingType = function(index){
+				if (index===OVERALL) {
+					$scope.selectedTrainingType = OVERALL;
+					$log.debug("Inside Selected Training Type")
+
+				} else {
+					$scope.selectedTrainingType = $scope.trainingTypes[index];
+					$log.debug($scope.TrainingType);
+				}
+
+				selectView($scope.currentBatch.batchId,
+						$scope.reportCurrentWeek,
+						$scope.currentTraineeId);
+
+			};
+
+			$scope.selectSkill = function(index){
+				$log.debug("Hello there Y1");
+				$log.debug(index);
+				$log.debug("Hello there Y2");
+				if (index===OVERALL) {
+					$scope.selectedSkill = OVERALL;
+
+				} else {
+					$scope.selectedSkill = $scope.skillstack[index];
+					$log.debug($scope.selectedSkill);
+
+				}
+
+				selectView($scope.currentBatch.batchId,
+						$scope.reportCurrentWeek,
+						$scope.currentTraineeId);
+
+			};
+
+
+
+
+			/*
+			 * scope function to display the table if a batch and week
+			 * has been selected
+			 */
+			$scope.displayTable = function() {
+				if ($scope.currentBatch === null
+						|| $scope.currentWeek === null) { 
+					return false;
+				}
+				return true;
+			}
+			$scope.displayTraineeOverallTable = function() {
+				if ($scope.currentBatch === null
+						|| $scope.currentWeek === null
+						|| $scope.batchOverallTrainee === null) {
+					return false;
+				} 
+				return true;
+			}
+			$scope.selectCurrentTrainee = function(index) {
+				if (index === ALL) {
 					$scope.currentTrainee = {
-						name : "Trainee",
+							name : "Trainee"
 					}
-					// hide filter tabs
-					$scope.hideOtherTabs = function() {
-						if($scope.currentBatch)
-							return $scope.currentBatch.trainingName !== "Batch";
-					}
+					$scope.currentTraineeId = ALL;
+					selectView($scope.currentBatch.batchId,
+							$scope.reportCurrentWeek,
+							$scope.currentTraineeId);
+				} else {
+					$scope.currentTraineeId = $scope.currentBatch.trainees[index].traineeId;
+					$scope.currentTrainee = $scope.currentBatch.trainees[index];
+					$log.debug($scope.currentTrainee);
+					selectView($scope.currentBatch.batchId,
+							$scope.reportCurrentWeek,
+							$scope.currentTraineeId);
+				}
+			}
 
-					function addYears() {
-						var currentYear = new Date().getFullYear();
-						$scope.selectedYear = currentYear;
+			// Get Data for Trainees and Batch comparison
+			function createAllTraineesAndBatchRadarData(){
+				chartsDelegate.radar.data
+				.getAllTraineesAndBatchRadarChart($scope.currentBatch.batchId)
+				.then(function(data) {
+					$log.debug(data);
+					radarComparData = data;
+				})
+			}
 
-						var data = [];
-						// List all years from 2014 --> current year
-						for (var y = currentYear + 1; y >= currentYear - 2; y--) {
-							data.push(y)
-						}
-						return data;
-					}
-					function batchYears() {
-						$scope.batchesByYear = [];
-						for (var i = 0; i < allBatches.length; i++) {
-							if ($scope.selectedYear === Number(allBatches[i].startDate
-									.substr(0, 4))) {
-								$scope.batchesByYear.push(allBatches[i]);
-							}
-						}
-					}
+			// toggle Checked and Unchecked for Trainees
+			$scope.toggleComparisonRadarChart = function(isChecked, val) {
+				radarComparObj[$scope.currentBatch.trainingName] = $scope.currentBatch.averageGrades;
+				if(isChecked) {
+					radarComparObj[$scope.currentBatch.trainees[val].name] = radarComparData[$scope.currentBatch.trainees[val].name];
+				} else {
+					delete radarComparObj[$scope.currentBatch.trainees[val].name];
+				}
 
-					$scope.selectYear = function(index) {
-						$scope.selectedYear = $scope.years[index];
-						sortByDate($scope.selectedYear);
-						batchYears();
-						$scope.currentBatch = $scope.batchesByYear[0];
-						$scope.reportCurrentWeek = OVERALL;
-						$scope.currentTraineeId = ALL;
-						if($scope.currentBatch)
-							selectView($scope.currentBatch.batchId,
-									$scope.reportCurrentWeek,
-									$scope.currentTraineeId);
-					};
+				var radarBatchOverallChartObject = chartsDelegate.radar
+				.getCombineBatchAndAllTraineeAssess(
+						radarComparObj);
+				$scope.radarBatchOverallData = radarBatchOverallChartObject.data;
+				$scope.radarBatchOverallOptions = radarBatchOverallChartObject.options;
+				$scope.radarBatchOverallLabels = radarBatchOverallChartObject.labels;
+				$scope.radarBatchOverallSeries = radarBatchOverallChartObject.series;
+				$scope.radarBatchOverallColors = radarBatchOverallChartObject.colors;
 
-					function sortByDate(currentYear) {
-						$scope.selectedBatches = [];
-						for (var i = 0; i < $scope.batches.length; i++) {
-							var date = new Date($scope.batches[i].startDate);
-							if (date.getFullYear() === currentYear) {
-								$scope.selectedBatches.push($scope.batches[i]);
-							}
-						}
-					}
+				$scope.radarBatchOverallTable = chartsDelegate.utility
+				.dataToTable(radarBatchOverallChartObject);
+				$log.debug(radarBatchOverallChartObject);
+			}
 
-					$scope.selectCurrentBatch = function(index) {
-						$scope.currentBatch = $scope.batchesByYear[index];
-						getCurrentBatchWeeks($scope.currentBatch.weeks);
-						$scope.reportCurrentWeek = OVERALL;
-						$scope.currentTraineeId = ALL;
-						selectView($scope.currentBatch.batchId,
-								$scope.reportCurrentWeek,
-								$scope.currentTraineeId);
-					}
+			function getAllTrainingTypes() {
+				caliberDelegate.all.enumTrainingType().then(
+						function(trainingType) {
+							$log.debug(trainingType);
+							$scope.trainingTypes = trainingType;
+						});
+			}
 
-					$scope.selectCurrentWeek = function(week) {
-						$scope.currentWeek = week;
-						$scope.reportCurrentWeek = week;
-						selectView($scope.currentBatch.batchId,
-								$scope.reportCurrentWeek,
-								$scope.currentTraineeId);
-					}
-					
-					$scope.selectTrainingType = function(index){
-						if (index===OVERALL) {
-							$scope.selectedTrainingType = OVERALL;
-							$log.debug("Inside Selected Training Type")
-			
-						} else {
-							$scope.selectedTrainingType = $scope.trainingTypes[index];
-							$log.debug($scope.TrainingType);
-						}
-						
-						selectView($scope.currentBatch.batchId,
-								$scope.reportCurrentWeek,
-								$scope.currentTraineeId);
-						
-					};
-					
-					$scope.selectSkill = function(index){
-						$log.debug("Hello there Y1");
-						$log.debug(index);
-						$log.debug("Hello there Y2");
-						if (index===OVERALL) {
-							$scope.selectedSkill = OVERALL;
-			
-						} else {
-							$scope.selectedSkill = $scope.skillstack[index];
-							$log.debug($scope.selectedSkill);
-		
-						}
-						
-						selectView($scope.currentBatch.batchId,
-								$scope.reportCurrentWeek,
-								$scope.currentTraineeId);
-						
-					};
-					
-					
-					
-					
-					/*
-					 * scope function to display the table if a batch and week
-					 * has been selected
-					 */
-					$scope.displayTable = function() {
-						if ($scope.currentBatch === null
-								|| $scope.currentWeek === null) { 
-							return false;
-						}
-						return true;
-					}
-					$scope.displayTraineeOverallTable = function() {
-						if ($scope.currentBatch === null
-								|| $scope.currentWeek === null
-								|| $scope.batchOverallTrainee === null) {
-							return false;
-						} 
-						return true;
-					}
-					$scope.selectCurrentTrainee = function(index) {
-						if (index === ALL) {
-							$scope.currentTrainee = {
-								name : "Trainee"
-							}
-							$scope.currentTraineeId = ALL;
-							selectView($scope.currentBatch.batchId,
-									$scope.reportCurrentWeek,
-									$scope.currentTraineeId);
-						} else {
-							$scope.currentTraineeId = $scope.currentBatch.trainees[index].traineeId;
-							$scope.currentTrainee = $scope.currentBatch.trainees[index];
-							$log.debug($scope.currentTrainee);
-							selectView($scope.currentBatch.batchId,
-									$scope.reportCurrentWeek,
-									$scope.currentTraineeId);
-						}
-					}
-					
-					// Get Data for Trainees and Batch comparison
-					function createAllTraineesAndBatchRadarData(){
-						chartsDelegate.radar.data
-						.getAllTraineesAndBatchRadarChart($scope.currentBatch.batchId)
-						.then(function(data) {
-							$log.debug(data);
-							radarComparData = data;
-						})
-					}
-					
-					// toggle Checked and Unchecked for Trainees
-					$scope.toggleComparisonRadarChart = function(isChecked, val) {
-						radarComparObj[$scope.currentBatch.trainingName] = $scope.currentBatch.averageGrades;
-						if(isChecked) {
-							radarComparObj[$scope.currentBatch.trainees[val].name] = radarComparData[$scope.currentBatch.trainees[val].name];
-						} else {
-							delete radarComparObj[$scope.currentBatch.trainees[val].name];
-						}
+			// *******************************************************************************
+			// *** Chart Generation
+			// *******************************************************************************
 
-						var radarBatchOverallChartObject = chartsDelegate.radar
-								.getCombineBatchAndAllTraineeAssess(
-										radarComparObj);
-						$scope.radarBatchOverallData = radarBatchOverallChartObject.data;
-						$scope.radarBatchOverallOptions = radarBatchOverallChartObject.options;
-						$scope.radarBatchOverallLabels = radarBatchOverallChartObject.labels;
-						$scope.radarBatchOverallSeries = radarBatchOverallChartObject.series;
-						$scope.radarBatchOverallColors = radarBatchOverallChartObject.colors;
-						
-						$scope.radarBatchOverallTable = chartsDelegate.utility
-						.dataToTable(radarBatchOverallChartObject);
-						$log.debug(radarBatchOverallChartObject);
-					}
-					
-					function getAllTrainingTypes() {
-						caliberDelegate.all.enumTrainingType().then(
-								function(trainingType) {
-									$log.debug(trainingType);
-									$scope.trainingTypes = trainingType;
+			function createBatchWeek() {
+				NProgress.done();
+				NProgress.start();
+
+				createQCStatus();
+				createAverageTraineeScoresWeekly();
+				createAssessmentAveragesBatchWeekly();
+			}
+
+			function createBatchWeekTrainee() {
+				NProgress.done();
+				NProgress.start();
+
+				createAssessmentAveragesTraineeWeekly();
+				createTechnicalSkillsTraineeWeekly();
+				createWeeklyProgressTraineeWeekly();
+			}
+
+			function createBatchOverall() {
+				NProgress.done();
+				NProgress.start();
+
+				createAverageTraineeScoresOverall();
+				createTechnicalSkillsBatchOverall();
+				createAllTraineesAndBatchRadarData();
+				createWeeklyProgressBatchOverall();
+			}
+
+			function createBatchOverallTrainee() {
+				NProgress.done();
+				NProgress.start();
+
+				createAssessmentAveragesTraineeOverall();
+				createWeeklyProgressTraineeOverall();
+				createTechnicalSkillsTraineeOverall();
+			}
+
+			// *******************************************************************************
+			// *** Doughnut Charts
+			// *******************************************************************************
+
+			function createQCStatus() {
+				chartsDelegate.doughnut.data
+				.getQCStatsData($scope.currentBatch.batchId,
+						$scope.reportCurrentWeek)
+						.then(
+								function(data) {
+									NProgress.done();
+									var doughnutChartObject = chartsDelegate.doughnut
+									.getQCStats(data);
+									$scope.qcStatsLabels = doughnutChartObject.labels;
+									$scope.qcStatsData = doughnutChartObject.data;
+									$scope.qcStatsOptions = doughnutChartObject.options;
+									$scope.qcStatsColors = doughnutChartObject.colors;
 								});
-					}
-					
-					// *******************************************************************************
-					// *** Chart Generation
-					// *******************************************************************************
 
-					function createBatchWeek() {
-						NProgress.done();
-						NProgress.start();
+			}
 
-						createQCStatus();
-						createAverageTraineeScoresWeekly();
-						createAssessmentAveragesBatchWeekly();
-					}
+			// *******************************************************************************
+			// *** Bar Charts
+			// *******************************************************************************
 
-					function createBatchWeekTrainee() {
-						NProgress.done();
-						NProgress.start();
-
-						createAssessmentAveragesTraineeWeekly();
-						createTechnicalSkillsTraineeWeekly();
-						createWeeklyProgressTraineeWeekly();
-					}
-
-					function createBatchOverall() {
-						NProgress.done();
-						NProgress.start();
-
-						createAverageTraineeScoresOverall();
-						createTechnicalSkillsBatchOverall();
-						createAllTraineesAndBatchRadarData();
-						createWeeklyProgressBatchOverall();
-					}
-
-					function createBatchOverallTrainee() {
-						NProgress.done();
-						NProgress.start();
-
-						createAssessmentAveragesTraineeOverall();
-						createWeeklyProgressTraineeOverall();
-						createTechnicalSkillsTraineeOverall();
-					}
-
-					// *******************************************************************************
-					// *** Doughnut Charts
-					// *******************************************************************************
-
-					function createQCStatus() {
-						chartsDelegate.doughnut.data
-								.getQCStatsData($scope.currentBatch.batchId,
-										$scope.reportCurrentWeek)
-								.then(
-										function(data) {
-											NProgress.done();
-											var doughnutChartObject = chartsDelegate.doughnut
-													.getQCStats(data);
-											$scope.qcStatsLabels = doughnutChartObject.labels;
-											$scope.qcStatsData = doughnutChartObject.data;
-											$scope.qcStatsOptions = doughnutChartObject.options;
-											$scope.qcStatsColors = doughnutChartObject.colors;
-										});
-
-					}
-
-					// *******************************************************************************
-					// *** Bar Charts
-					// *******************************************************************************
-
-					function createAverageTraineeScoresWeekly() {
-						chartsDelegate.bar
-						.getBatchComparisonLineData($scope.selectedSkill, 
-								$scope.selectedTrainingType, 
-								$scope.startDate)
-								.then(
-										function(comparison) {
-											chartsDelegate.bar.data
-											.getAverageTraineeScoresWeeklyData(
-													$scope.currentBatch.batchId,
-													$scope.reportCurrentWeek)
+			function createAverageTraineeScoresWeekly() {
+				chartsDelegate.bar
+				.getBatchComparisonLineData($scope.selectedSkill, 
+						$scope.selectedTrainingType, 
+						$scope.startDate)
+						.then(
+								function(comparison) {
+									chartsDelegate.bar.data
+									.getAverageTraineeScoresWeeklyData(
+											$scope.currentBatch.batchId,
+											$scope.reportCurrentWeek)
 											.then(
 													function(data) {
 														NProgress.done();
 														var barChartObj = chartsDelegate.bar
-																.getAverageTraineeScoresWeekly(data, comparison, $scope.currentBatch.borderlineGradeThreshold, $scope.currentBatch.goodGradeThreshold);
+														.getAverageTraineeScoresWeekly(data, comparison, $scope.currentBatch.borderlineGradeThreshold, $scope.currentBatch.goodGradeThreshold);
 														$scope.averageTraineeScoresWeeklyData = barChartObj.data;
 														$scope.averageTraineeScoresWeeklyLabels = barChartObj.labels;
 														$scope.averageTraineeScoresWeeklySeries = barChartObj.series;
@@ -452,19 +495,19 @@ angular
 													}, function() {
 														NProgress.done();
 													});
-											});
-					}
-				
-					// Hossain bar chart trainee vs average all week score
-					function createAverageTraineeScoresOverall() {
-						chartsDelegate.bar
-						.getBatchComparisonLineData($scope.selectedSkill, 
-								$scope.selectedTrainingType, 
-								$scope.startDate)
-								.then(
-										function(comparison) {
-											chartsDelegate.bar.data
-											.getAverageTraineeScoresOverallData(
+								});
+			}
+
+			// Hossain bar chart trainee vs average all week score
+			function createAverageTraineeScoresOverall() {
+				chartsDelegate.bar
+				.getBatchComparisonLineData($scope.selectedSkill, 
+						$scope.selectedTrainingType, 
+						$scope.startDate)
+						.then(
+								function(comparison) {
+									chartsDelegate.bar.data
+									.getAverageTraineeScoresOverallData(
 											$scope.currentBatch.batchId)
 											// confirm if batch or trainee
 											.then(
@@ -480,395 +523,395 @@ angular
 													}, function() {
 														NProgress.done();
 													});
-										});
-					}
-
-					// Yanilda barchart
-					function createAssessmentAveragesBatchWeekly() {
-						chartsDelegate.bar.data
-								.getAssessmentAveragesBatchWeeklyData(
-										$scope.currentBatch.batchId,
-										$scope.reportCurrentWeek)
-								.then(
-										function(data) {
-											NProgress.done();
-											var barChartObject = chartsDelegate.bar
-													.getAssessmentAveragesBatchWeekly(data);
-											$scope.barchartAWLabels = barChartObject.labels;
-											$scope.barchartAWData = barChartObject.data;
-											$scope.barchartAWOptions = barChartObject.options;
-											$scope.barchartAWSeries = barChartObject.series;
-											$scope.barchartAWColors = barChartObject.colors;
-										}, function() {
-											NProgress.done();
-										});
-
-					}
-		
-
-					function createAssessmentAveragesTraineeWeekly() {
-						chartsDelegate.bar.data
-								.getAssessmentAveragesTraineeWeeklyData(
-										$scope.currentBatch.batchId,
-										$scope.reportCurrentWeek,
-										$scope.currentTraineeId)
-								.then(
-										function(data) {
-											NProgress.done();
-											var barChartObject = chartsDelegate.bar
-													.getAssessmentAveragesTraineeWeekly(data);
-											$scope.AssessmentAveragesTraineeWeeklyLabels = barChartObject.labels;
-											$scope.AssessmentAveragesTraineeWeeklyData = barChartObject.data;
-											$scope.AssessmentAveragesTraineeWeeklyOptions = barChartObject.options;
-											$scope.AssessmentAveragesTraineeWeeklySeries = barChartObject.series;
-											$scope.AssessmentAveragesTraineeWeeklyColors = barChartObject.colors;
-										}, function() {
-											NProgress.done();
-										});
-
-					}
-
-					function createAssessmentAveragesTraineeOverall() {
-						chartsDelegate.bar.data
-								.getAssessmentAveragesTraineeOverallData(
-										$scope.currentBatch.batchId,
-										$scope.currentTraineeId)
-								.then(
-										function(data) {
-											NProgress.done();
-											var barChartObject = chartsDelegate.bar
-													.getAssessmentAveragesTraineeOverall(data);
-											$scope.AssessmentAveragesTraineeOverallLabels = barChartObject.labels;
-											$scope.AssessmentAveragesTraineeOverallData = barChartObject.data;
-											$scope.AssessmentAveragesTraineeOverallOptions = barChartObject.options;
-											$scope.AssessmentAveragesTraineeOverallSeries = barChartObject.series;
-											$scope.AssessmentAveragesTraineeOverallColors = barChartObject.colors;
-										}, function() {
-											NProgress.done();
-										});
-
-					}
-
-					// *******************************************************************************
-					// *** Radar Charts
-					// *******************************************************************************
-					function createTechnicalSkillsTraineeWeekly() {
-						$log.debug("createTechnicalSkillsTraineeWeekly");
-						chartsDelegate.radar.data
-								.getTraineAndBatchSkillComparisonChart(
-										$scope.currentBatch.batchId,
-										$scope.reportCurrentWeek,
-										$scope.currentTraineeId)
-								.then(
-										function(data) {
-											NProgress.done();
-											var radarChartObject = chartsDelegate.radar
-													.createFromTwoDataSets(
-															data.batch,
-															data.trainee,
-															$scope.currentBatch.trainingName,
-															$scope.currentTrainee.name);
-
-											$scope.radarTraineeWeeklyData = radarChartObject.data;
-											$scope.radarTraineeWeeklyOptions = radarChartObject.options;
-											$scope.radarTraineeWeeklyLabels = radarChartObject.labels;
-											$scope.radarTraineeWeeklySeries = radarChartObject.series;
-											$scope.radarTraineeWeeklyColors = radarChartObject.colors;
-
-											$scope.radarTraineeWeeklyTable = chartsDelegate.utility
-													.dataToTable(radarChartObject);
-										});
-					}
-
-					function createTechnicalSkillsTraineeOverall() {
-						$log.debug("createTechnicalSkillsTraineeOverall");
-						chartsDelegate.radar.data
-								.getTraineAndBatchSkillComparisonChart(
-										$scope.currentBatch.batchId,
-										$scope.reportCurrentWeek,
-										$scope.currentTraineeId)
-								.then(
-										function(data) {
-											NProgress.done();
-											var radarChartObject = chartsDelegate.radar
-													.createFromTwoDataSets(
-															data.batch,
-															data.trainee,
-															$scope.currentBatch.trainingName,
-															$scope.currentTrainee.name);
-
-											$scope.radarTraineeOverallData = radarChartObject.data;
-											$scope.radarTraineeOverallOptions = radarChartObject.options;
-											$scope.radarTraineeOverallLabels = radarChartObject.labels;
-											$scope.radarTraineeOverallSeries = radarChartObject.series;
-											$scope.radarTraineeOverallColors = radarChartObject.colors;
-
-											$scope.radarTraineeOverallTable = chartsDelegate.utility
-													.dataToTable(radarChartObject);
-										});
-					}
-
-					function createTechnicalSkillsBatchOverall() {
-						$log.debug("createTechnicalSkillsBatchOverall");
-						chartsDelegate.radar.data
-								.getTechnicalSkillsBatchOverallData(
-										$scope.currentBatch.batchId)
-								// batchId
-								.then(
-										function(data) {
-											$log.debug("Batch overall radar data: ");
-											$log.debug(data);
-											NProgress.done();
-											
-											/*store this is $scope.currentBatch.averageGrades for accessing this information
-											so you do not have to make another HTTP request*/
-											$scope.currentBatch.averageGrades = data;
-											
-											var radarBatchOverallChartObject = chartsDelegate.radar
-													.getTechnicalSkillsBatchOverall(
-															data,
-															$scope.currentBatch.trainingName);
-											$scope.radarBatchOverallData = radarBatchOverallChartObject.data;
-											$scope.radarBatchOverallOptions = radarBatchOverallChartObject.options;
-											$scope.radarBatchOverallLabels = radarBatchOverallChartObject.labels;
-											$scope.radarBatchOverallSeries = radarBatchOverallChartObject.series;
-											$scope.radarBatchOverallColors = radarBatchOverallChartObject.colors;
-
-											$scope.radarBatchOverallTable = chartsDelegate.utility
-													.dataToTable(radarBatchOverallChartObject);
-										});
-
-					}
-					
-					// *******************************************************************************
-					// *** Line Charts
-					// *******************************************************************************
-
-					function createWeeklyProgressBatchOverall() {
-						chartsDelegate.line.data
-								.getWeeklyProgressBatchOverallData(
-										$scope.currentBatch.batchId)
-								.then(
-										function(data) {
-											NProgress.done();
-											var lineChartObj = chartsDelegate.line
-													.getWeeklyProgressBatchOverall(data);
-											$scope.weeklyProgressBatchOverallLabels = lineChartObj.labels;
-											$scope.weeklyProgressBatchOverallData = lineChartObj.data;
-											$scope.weeklyProgressBatchOverallOptions = lineChartObj.options;
-											$scope.weeklyProgressBatchOverallColors = lineChartObj.colors;
-											$scope.weeklyProgressBatchOverallDsOverride = lineChartObj.datasetOverride;
-										}, function() {
-											NProgress.done();
-										})
-					}
-
-					// Yanilda
-					function createWeeklyProgressTraineeWeekly() {
-						chartsDelegate.line.data
-								.getWeeklyProgressTraineeWeeklyData($scope.currentBatch.batchId,
-										$scope.reportCurrentWeek,
-										$scope.currentTraineeId)
-								.then(
-										function(data) {
-											NProgress.done();
-											var lineChartObjectwd = chartsDelegate.line
-													.getWeeklyProgressTraineeWeekly(data);
-											$scope.linechartTWLabels = lineChartObjectwd.labels;
-											$scope.linechartTWData = lineChartObjectwd.data;
-											$scope.linechartTWOptions = lineChartObjectwd.options;
-											$scope.linechartTWSeries = lineChartObjectwd.series;
-											$scope.linechartTWColors = lineChartObjectwd.colors;
-											$scope.linechartTWDsOverride = lineChartObjectwd.datasetOverride;
-										}, function() {
-											NProgress.done();
-										});
-
-					}
-
-					function createWeeklyProgressTraineeOverall() {
-						chartsDelegate.line.data
-								.getWeeklyProgressTraineeOverallData(
-										$scope.currentBatch.batchId,
-										$scope.currentTraineeId)
-								.then(
-										function(data) {
-											NProgress.done();
-											var lineChartObject = chartsDelegate.line
-													.getWeeklyProgressTraineeOverall(data);
-											$scope.batchOverallWeeklyLabels = lineChartObject.labels;
-											$scope.batchOverallWeeklyData = lineChartObject.data;
-											$scope.batchOverallWeeklySeries = lineChartObject.series;
-											$scope.batchOverallWeeklyOptions = lineChartObject.options;
-											$scope.batchOverallWeeklyColors = lineChartObject.colors;
-											$scope.batchOverallWeeklyDsOverride = lineChartObject.datasetOverride;
-										}, function() {
-											NProgress.done();
-										});
-
-					}
-
-					// *******************************************************************************
-					// *** PDF Generation
-					// *******************************************************************************
-					/**
-					 * Generates a PDF by sending HTML to server. Downloads
-					 * automatically in new tab.
-					 */
-					$scope.generatePDF = function() {
-						if($scope.noBatch)
-							return;
-						// indicate to user the PDF is processing
-						$scope.reticulatingSplines = true;
-
-						// get html element #caliber-container
-						var caliber = document
-								.getElementById("caliber-container");
-						// create deep copy to manipulate for POST request body
-						var clone = document
-								.getElementById("caliber-container").cloneNode(
-										true);
-						$log.debug(caliber);
-
-						// iterate over all childrens to convert <canvas> to
-						// <img src=base64>
-						var html = $scope.generateImgFromCanvas(caliber, clone).innerHTML;
-
-						var title;
-						// generate the title
-						if ($scope.currentTraineeId === ALL && $scope.reportCurrentWeek !== OVERALL)
-							title = "Week " + $scope.currentWeek
-									+ " Progress for "
-									+ $scope.currentBatch.trainingName;
-						else if ($scope.currentTraineeId !== ALL && $scope.reportCurrentWeek === OVERALL)
-							title = "Progress for "
-									+ $scope.currentTrainee.name;
-						else if ($scope.currentTraineeId !== ALL && $scope.reportCurrentWeek !== OVERALL)
-							title = "Week " + $scope.currentWeek + 
-									" Progress for "
-									+ $scope.currentTrainee.name;
-						else
-							title = "Performance at a Glance for " + $scope.currentBatch.trainingName;
-
-						// send to server and download generated PDF
-						caliberDelegate.all.generatePDF(title, html).then(
-								function(pdf) {
-									// extract PDF bytes
-									var file = new Blob([ pdf ], {
-										type : "application/pdf"
-									});
-									// create temporary 'url' and download
-									// automatically
-									var fileURL = URL.createObjectURL(file);
-									var a = document.createElement("a");
-									a.href = fileURL;
-									a.target = "_blank";
-									a.download = title + ".pdf";
-									document.body.appendChild(a);
-									a.click();
-									$scope.reticulatingSplines = false;
-								}, function(error) {
-									$log.debug(error);
-								}, function(value) {
-									$log.debug(value);
 								});
+			}
+
+			// Yanilda barchart
+			function createAssessmentAveragesBatchWeekly() {
+				chartsDelegate.bar.data
+				.getAssessmentAveragesBatchWeeklyData(
+						$scope.currentBatch.batchId,
+						$scope.reportCurrentWeek)
+						.then(
+								function(data) {
+									NProgress.done();
+									var barChartObject = chartsDelegate.bar
+									.getAssessmentAveragesBatchWeekly(data);
+									$scope.barchartAWLabels = barChartObject.labels;
+									$scope.barchartAWData = barChartObject.data;
+									$scope.barchartAWOptions = barChartObject.options;
+									$scope.barchartAWSeries = barChartObject.series;
+									$scope.barchartAWColors = barChartObject.colors;
+								}, function() {
+									NProgress.done();
+								});
+
+			}
+
+
+			function createAssessmentAveragesTraineeWeekly() {
+				chartsDelegate.bar.data
+				.getAssessmentAveragesTraineeWeeklyData(
+						$scope.currentBatch.batchId,
+						$scope.reportCurrentWeek,
+						$scope.currentTraineeId)
+						.then(
+								function(data) {
+									NProgress.done();
+									var barChartObject = chartsDelegate.bar
+									.getAssessmentAveragesTraineeWeekly(data);
+									$scope.AssessmentAveragesTraineeWeeklyLabels = barChartObject.labels;
+									$scope.AssessmentAveragesTraineeWeeklyData = barChartObject.data;
+									$scope.AssessmentAveragesTraineeWeeklyOptions = barChartObject.options;
+									$scope.AssessmentAveragesTraineeWeeklySeries = barChartObject.series;
+									$scope.AssessmentAveragesTraineeWeeklyColors = barChartObject.colors;
+								}, function() {
+									NProgress.done();
+								});
+
+			}
+
+			function createAssessmentAveragesTraineeOverall() {
+				chartsDelegate.bar.data
+				.getAssessmentAveragesTraineeOverallData(
+						$scope.currentBatch.batchId,
+						$scope.currentTraineeId)
+						.then(
+								function(data) {
+									NProgress.done();
+									var barChartObject = chartsDelegate.bar
+									.getAssessmentAveragesTraineeOverall(data);
+									$scope.AssessmentAveragesTraineeOverallLabels = barChartObject.labels;
+									$scope.AssessmentAveragesTraineeOverallData = barChartObject.data;
+									$scope.AssessmentAveragesTraineeOverallOptions = barChartObject.options;
+									$scope.AssessmentAveragesTraineeOverallSeries = barChartObject.series;
+									$scope.AssessmentAveragesTraineeOverallColors = barChartObject.colors;
+								}, function() {
+									NProgress.done();
+								});
+
+			}
+
+			// *******************************************************************************
+			// *** Radar Charts
+			// *******************************************************************************
+			function createTechnicalSkillsTraineeWeekly() {
+				$log.debug("createTechnicalSkillsTraineeWeekly");
+				chartsDelegate.radar.data
+				.getTraineAndBatchSkillComparisonChart(
+						$scope.currentBatch.batchId,
+						$scope.reportCurrentWeek,
+						$scope.currentTraineeId)
+						.then(
+								function(data) {
+									NProgress.done();
+									var radarChartObject = chartsDelegate.radar
+									.createFromTwoDataSets(
+											data.batch,
+											data.trainee,
+											$scope.currentBatch.trainingName,
+											$scope.currentTrainee.name);
+
+									$scope.radarTraineeWeeklyData = radarChartObject.data;
+									$scope.radarTraineeWeeklyOptions = radarChartObject.options;
+									$scope.radarTraineeWeeklyLabels = radarChartObject.labels;
+									$scope.radarTraineeWeeklySeries = radarChartObject.series;
+									$scope.radarTraineeWeeklyColors = radarChartObject.colors;
+
+									$scope.radarTraineeWeeklyTable = chartsDelegate.utility
+									.dataToTable(radarChartObject);
+								});
+			}
+
+			function createTechnicalSkillsTraineeOverall() {
+				$log.debug("createTechnicalSkillsTraineeOverall");
+				chartsDelegate.radar.data
+				.getTraineAndBatchSkillComparisonChart(
+						$scope.currentBatch.batchId,
+						$scope.reportCurrentWeek,
+						$scope.currentTraineeId)
+						.then(
+								function(data) {
+									NProgress.done();
+									var radarChartObject = chartsDelegate.radar
+									.createFromTwoDataSets(
+											data.batch,
+											data.trainee,
+											$scope.currentBatch.trainingName,
+											$scope.currentTrainee.name);
+
+									$scope.radarTraineeOverallData = radarChartObject.data;
+									$scope.radarTraineeOverallOptions = radarChartObject.options;
+									$scope.radarTraineeOverallLabels = radarChartObject.labels;
+									$scope.radarTraineeOverallSeries = radarChartObject.series;
+									$scope.radarTraineeOverallColors = radarChartObject.colors;
+
+									$scope.radarTraineeOverallTable = chartsDelegate.utility
+									.dataToTable(radarChartObject);
+								});
+			}
+
+			function createTechnicalSkillsBatchOverall() {
+				$log.debug("createTechnicalSkillsBatchOverall");
+				chartsDelegate.radar.data
+				.getTechnicalSkillsBatchOverallData(
+						$scope.currentBatch.batchId)
+						// batchId
+						.then(
+								function(data) {
+									$log.debug("Batch overall radar data: ");
+									$log.debug(data);
+									NProgress.done();
+
+									/*store this is $scope.currentBatch.averageGrades for accessing this information
+											so you do not have to make another HTTP request*/
+									$scope.currentBatch.averageGrades = data;
+
+									var radarBatchOverallChartObject = chartsDelegate.radar
+									.getTechnicalSkillsBatchOverall(
+											data,
+											$scope.currentBatch.trainingName);
+									$scope.radarBatchOverallData = radarBatchOverallChartObject.data;
+									$scope.radarBatchOverallOptions = radarBatchOverallChartObject.options;
+									$scope.radarBatchOverallLabels = radarBatchOverallChartObject.labels;
+									$scope.radarBatchOverallSeries = radarBatchOverallChartObject.series;
+									$scope.radarBatchOverallColors = radarBatchOverallChartObject.colors;
+
+									$scope.radarBatchOverallTable = chartsDelegate.utility
+									.dataToTable(radarBatchOverallChartObject);
+								});
+
+			}
+
+			// *******************************************************************************
+			// *** Line Charts
+			// *******************************************************************************
+
+			function createWeeklyProgressBatchOverall() {
+				chartsDelegate.line.data
+				.getWeeklyProgressBatchOverallData(
+						$scope.currentBatch.batchId)
+						.then(
+								function(data) {
+									NProgress.done();
+									var lineChartObj = chartsDelegate.line
+									.getWeeklyProgressBatchOverall(data);
+									$scope.weeklyProgressBatchOverallLabels = lineChartObj.labels;
+									$scope.weeklyProgressBatchOverallData = lineChartObj.data;
+									$scope.weeklyProgressBatchOverallOptions = lineChartObj.options;
+									$scope.weeklyProgressBatchOverallColors = lineChartObj.colors;
+									$scope.weeklyProgressBatchOverallDsOverride = lineChartObj.datasetOverride;
+								}, function() {
+									NProgress.done();
+								})
+			}
+
+			// Yanilda
+			function createWeeklyProgressTraineeWeekly() {
+				chartsDelegate.line.data
+				.getWeeklyProgressTraineeWeeklyData($scope.currentBatch.batchId,
+						$scope.reportCurrentWeek,
+						$scope.currentTraineeId)
+						.then(
+								function(data) {
+									NProgress.done();
+									var lineChartObjectwd = chartsDelegate.line
+									.getWeeklyProgressTraineeWeekly(data);
+									$scope.linechartTWLabels = lineChartObjectwd.labels;
+									$scope.linechartTWData = lineChartObjectwd.data;
+									$scope.linechartTWOptions = lineChartObjectwd.options;
+									$scope.linechartTWSeries = lineChartObjectwd.series;
+									$scope.linechartTWColors = lineChartObjectwd.colors;
+									$scope.linechartTWDsOverride = lineChartObjectwd.datasetOverride;
+								}, function() {
+									NProgress.done();
+								});
+
+			}
+
+			function createWeeklyProgressTraineeOverall() {
+				chartsDelegate.line.data
+				.getWeeklyProgressTraineeOverallData(
+						$scope.currentBatch.batchId,
+						$scope.currentTraineeId)
+						.then(
+								function(data) {
+									NProgress.done();
+									var lineChartObject = chartsDelegate.line
+									.getWeeklyProgressTraineeOverall(data);
+									$scope.batchOverallWeeklyLabels = lineChartObject.labels;
+									$scope.batchOverallWeeklyData = lineChartObject.data;
+									$scope.batchOverallWeeklySeries = lineChartObject.series;
+									$scope.batchOverallWeeklyOptions = lineChartObject.options;
+									$scope.batchOverallWeeklyColors = lineChartObject.colors;
+									$scope.batchOverallWeeklyDsOverride = lineChartObject.datasetOverride;
+								}, function() {
+									NProgress.done();
+								});
+
+			}
+
+			// *******************************************************************************
+			// *** PDF Generation
+			// *******************************************************************************
+			/**
+			 * Generates a PDF by sending HTML to server. Downloads
+			 * automatically in new tab.
+			 */
+			$scope.generatePDF = function() {
+				if($scope.noBatch)
+					return;
+				// indicate to user the PDF is processing
+				$scope.reticulatingSplines = true;
+
+				// get html element #caliber-container
+				var caliber = document
+				.getElementById("caliber-container");
+				// create deep copy to manipulate for POST request body
+				var clone = document
+				.getElementById("caliber-container").cloneNode(
+						true);
+				$log.debug(caliber);
+
+				// iterate over all childrens to convert <canvas> to
+				// <img src=base64>
+				var html = $scope.generateImgFromCanvas(caliber, clone).innerHTML;
+
+				var title;
+				// generate the title
+				if ($scope.currentTraineeId === ALL && $scope.reportCurrentWeek !== OVERALL)
+					title = "Week " + $scope.currentWeek
+					+ " Progress for "
+					+ $scope.currentBatch.trainingName;
+				else if ($scope.currentTraineeId !== ALL && $scope.reportCurrentWeek === OVERALL)
+					title = "Progress for "
+						+ $scope.currentTrainee.name;
+				else if ($scope.currentTraineeId !== ALL && $scope.reportCurrentWeek !== OVERALL)
+					title = "Week " + $scope.currentWeek + 
+					" Progress for "
+					+ $scope.currentTrainee.name;
+				else
+					title = "Performance at a Glance for " + $scope.currentBatch.trainingName;
+
+				// send to server and download generated PDF
+				caliberDelegate.all.generatePDF(title, html).then(
+						function(pdf) {
+							// extract PDF bytes
+							var file = new Blob([ pdf ], {
+								type : "application/pdf"
+							});
+							// create temporary 'url' and download
+							// automatically
+							var fileURL = URL.createObjectURL(file);
+							var a = document.createElement("a");
+							a.href = fileURL;
+							a.target = "_blank";
+							a.download = title + ".pdf";
+							document.body.appendChild(a);
+							a.click();
+							$scope.reticulatingSplines = false;
+						}, function(error) {
+							$log.debug(error);
+						}, function(value) {
+							$log.debug(value);
+						});
+			}
+
+			/**
+			 * Replace canvas (in DOM) with img (in deep copy)
+			 */
+			$scope.generateImgFromCanvas = function(dom, clone) {
+				for (var i = 0; i < dom.childNodes.length; i++) {
+					var child = dom.childNodes[i];
+					var cloneChild = clone.childNodes[i];
+					$scope.generateImgFromCanvas(child, cloneChild);
+					if (child.tagName === "CANVAS") {
+						// swap canvas for image with base64 src
+						var image = new Image();
+						image.src = child.toDataURL();
+						clone.replaceChild(image, cloneChild);
 					}
+				}
+				return clone;
+			};
 
-					/**
-					 * Replace canvas (in DOM) with img (in deep copy)
-					 */
-					$scope.generateImgFromCanvas = function(dom, clone) {
-						for (var i = 0; i < dom.childNodes.length; i++) {
-							var child = dom.childNodes[i];
-							var cloneChild = clone.childNodes[i];
-							$scope.generateImgFromCanvas(child, cloneChild);
-							if (child.tagName === "CANVAS") {
-								// swap canvas for image with base64 src
-								var image = new Image();
-								image.src = child.toDataURL();
-								clone.replaceChild(image, cloneChild);
-							}
-						}
-						return clone;
-					};
+			//DOWNLOAD INDIVIDUAL CHART AS PDF
+			$scope.downloadChartButton = function ($event){
+				//GET CURRENT ELEMENT'S PARENT'S PARENT'S PARENT
+				var element = $event.target.parentElement.parentElement;
+				var doc = new jsPDF('p', 'mm', 'a4');
+				doc.internal.scaleFactor = 4;
+				doc.addHTML(element, function (){
+					// GET CHART TEXT/TITLE FROM PANEL-HEADING
+					var filename = element.childNodes[1].innerText.trim() + '.pdf';
+					doc.save(filename);
+				});
+			};
 
-                    //DOWNLOAD INDIVIDUAL CHART AS PDF
-					$scope.downloadChartButton = function ($event){
-						//GET CURRENT ELEMENT'S PARENT'S PARENT'S PARENT
-						var element = $event.target.parentElement.parentElement;
-						var doc = new jsPDF('p', 'mm', 'a4');
-                        doc.internal.scaleFactor = 4;
-                        doc.addHTML(element, function (){
-							// GET CHART TEXT/TITLE FROM PANEL-HEADING
-							var filename = element.childNodes[1].innerText.trim() + '.pdf';
-                            doc.save(filename);
+			//DOWNLOAD ALL TRAINEE CHART AS PDF
+			$scope.downloadAllChartButton = function () {
+				//GET CALIBER CONTAINER ID THAT CONSIST OF ALL THE CHARTS UNDER REPORT
+				var element = angular.element(document.querySelector('#caliber-container')).children()[0];
+				var cumulativeScores = element.children[0].children[0].children[0];
+				var technicalSkillsAndWeeklyProgress = element.children[0].children[0].children[1];
+				var charts = [];
+
+				charts.push(cumulativeScores);
+				for (var i = 0; i < technicalSkillsAndWeeklyProgress.children.length; i++)
+					charts.push(technicalSkillsAndWeeklyProgress.children[i]);
+
+				var doc = new jsPDF('p', 'mm', 'a4');
+				doc.text(doc.internal.pageSize.width/2 - 20, 5, $scope.currentTrainee.name);
+				doc.internal.scaleFactor = 4;
+				var j = 0;
+				var recursiveAddHtml = function (height) {
+					if (j < charts.length) {
+						doc.addHTML(charts[j], 0, height, function () {
+							j++;
+							if (j !== charts.length)
+								doc.addPage();
+							recursiveAddHtml(0);
 						});
-					};
+					} else {
+						doc.save($scope.currentTrainee.name + '.pdf');
+					}
+				};
+				recursiveAddHtml(10);
+			};
 
-                    //DOWNLOAD ALL TRAINEE CHART AS PDF
-                    $scope.downloadAllChartButton = function () {
-                        //GET CALIBER CONTAINER ID THAT CONSIST OF ALL THE CHARTS UNDER REPORT
-                        var element = angular.element(document.querySelector('#caliber-container')).children()[0];
-                        var cumulativeScores = element.children[0].children[0].children[0];
-						var technicalSkillsAndWeeklyProgress = element.children[0].children[0].children[1];
-                        var charts = [];
+			// Gets notes (trainer and QC) for a specific trainee and
+			// the week
+			$scope.getTraineeNote=function(traineeId,weekId){
+				$log.debug("YOU ARE IN $scope.getTraineeNote("+ traineeId + "," + weekId + ")");
 
-                        charts.push(cumulativeScores);
-                        for (var i = 0; i < technicalSkillsAndWeeklyProgress.children.length; i++)
-                        	charts.push(technicalSkillsAndWeeklyProgress.children[i]);
+				// Denise
+				// gets trainer notes for the trainee and for that week
+				// and inserts it to the scope
+				caliberDelegate.trainer.getTraineeNote(traineeId,weekId).then(function(data){
+					$log.debug("YOU ARE IN get trainer caliber in controller");
+					$scope.note = {};
+					if(data){
+						$scope.note = data;
+					}
+				});
 
-                        var doc = new jsPDF('p', 'mm', 'a4');
-                        doc.text(doc.internal.pageSize.width/2 - 20, 5, $scope.currentTrainee.name);
-                        doc.internal.scaleFactor = 4;
-                        var j = 0;
-                        var recursiveAddHtml = function (height) {
-                            if (j < charts.length) {
-                                doc.addHTML(charts[j], 0, height, function () {
-                                    j++;
-                                    if (j !== charts.length)
-                                    	doc.addPage();
-                                    recursiveAddHtml(0);
-                                });
-                            } else {
-								doc.save($scope.currentTrainee.name + '.pdf');
-                            }
-                        };
-                        recursiveAddHtml(10);
-                    };
-					
-					// Gets notes (trainer and QC) for a specific trainee and
-					// the week
-					$scope.getTraineeNote=function(traineeId,weekId){
-						$log.debug("YOU ARE IN $scope.getTraineeNote("+ traineeId + "," + weekId + ")");
-						
-						// Denise
-						// gets trainer notes for the trainee and for that week
-						// and inserts it to the scope
-						caliberDelegate.trainer.getTraineeNote(traineeId,weekId).then(function(data){
-							$log.debug("YOU ARE IN get trainer caliber in controller");
-							$scope.note = {};
-							if(data){
-								$scope.note = data;
-							}
-						});
-						
-						// Michael get QCnote and QCstatus
-						caliberDelegate.qc.getQCTraineeNote(traineeId,weekId).then(function(data){
-							$log.debug("YOU ARE IN get qc caliber in controller");
-								$scope.qcNote = {};
-							if(data){
-								$scope.qcNote = data;
-							}
-						});
-						// Daniel get categories for the week
-						caliberDelegate.qc.getAllAssessmentCategories(
-								$scope.currentBatch.batchId,
-								$scope.currentWeek).then(
+				// Michael get QCnote and QCstatus
+				caliberDelegate.qc.getQCTraineeNote(traineeId,weekId).then(function(data){
+					$log.debug("YOU ARE IN get qc caliber in controller");
+					$scope.qcNote = {};
+					if(data){
+						$scope.qcNote = data;
+					}
+				});
+				// Daniel get categories for the week
+				caliberDelegate.qc.getAllAssessmentCategories(
+						$scope.currentBatch.batchId,
+						$scope.currentWeek).then(
 								function(response) {
 									$scope.categories = response;
 								});
-					}
-					
-				});
+			}
+
+		});
 
 

--- a/caliber/src/main/webapp/static/app/resources/js/controllers/allReportController.js
+++ b/caliber/src/main/webapp/static/app/resources/js/controllers/allReportController.js
@@ -67,19 +67,21 @@ angular
 				allBatches.forEach(function(batch){
 					batch.trainees.forEach(function(trainee){
 						if(trainee.name == traineeName){
-							//set view search defaults
+							//set view variables
 							$scope.reportCurrentWeek = '(All)';
 							$scope.currentBatch = batch;
 							$scope.currentTrainee = trainee;
 							$scope.currentTraineeId = trainee.traineeId;
 							$scope.selectedYear = Number($scope.currentBatch.startDate
-									.substr(0, 4));
+														.substr(0, 4));
 							getCurrentBatchWeeks($scope.currentBatch.weeks);
 
-							//set view
+							//select view display
 							selectView($scope.currentBatch.batchId,
 									$scope.reportCurrentWeek,
 									$scope.currentTraineeId);
+							
+							//end function
 							return;
 						}
 					});
@@ -94,6 +96,7 @@ angular
 				// get all training types for dropdown
 				getAllTrainingTypes();
 				// get all trainees for search results display
+				getTrainees();
 
 				if ($scope.currentBatch === null || $scope.currentBatch === undefined) {
 					$scope.noBatch = true;

--- a/caliber/src/main/webapp/static/pages/index.html
+++ b/caliber/src/main/webapp/static/pages/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <meta charset="ISO-8859-1">
+<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
 <!-- 
  _____                 _                  
 |  __ \               | |                 
@@ -28,7 +29,7 @@
 <script src="https://code.jquery.com/jquery-3.1.1.min.js"
 	integrity="sha256-hVVnYaiADRTO2PzUGmuLJr8BLUSjGIZsDYGmIJLv2b8="
 	crossorigin="anonymous"></script>
-
+ 
 <!-- Chart.js -->
 <!-- This is a dependency for creating charts in angular -->
 <script type="text/javascript"


### PR DESCRIPTION
### Purpose of Pull Request
As a user, I can search for one particular trainee on the Reports page to view their overall report. When I type into the search box, suggestions come up for trainees (like a Google search--see in HTML5). When I select the trainee, their overall report comes up with all the charts and tables needed for a comprehensive assessment of their skills.

Sometimes we need to jump to exactly the trainee we wish to get reports on. Makes life easier for Staging Manager especially when they need to quick locate a trainee to perform some assessment on them.

### Where should the reviewer start?
You would want to start by looking at the implementation on the reports page of each role type. Then look at the abstracts/reports html page then onto the allReportingController for getting the data values being set.

### What are the relevant stories/issues?
Relevant stories include browsing reports and generating reports for trainees and batches.
#616 

### Screenshots (if appropriate)
![search_reports](https://user-images.githubusercontent.com/31013786/31257321-0349c1da-aa06-11e7-977a-5149509601bd.png)
